### PR TITLE
refactor: fix a few typos

### DIFF
--- a/src/Checkbox/Checkbox.tsx
+++ b/src/Checkbox/Checkbox.tsx
@@ -119,7 +119,7 @@ export interface ICheckboxProps {
   /**
    * The callback function that is triggered when the state changes
    */
-  onChange?: (evnet: ChangeEvent) => void;
+  onChange?: (event: ChangeEvent) => void;
   /**
    * The value of checkbox
    */

--- a/src/Radio/Radio.tsx
+++ b/src/Radio/Radio.tsx
@@ -114,7 +114,7 @@ export interface IRadioProps {
   /**
    * The callback function that is triggered when the state changes
    */
-  onChange?: (evnet: ChangeEvent) => void;
+  onChange?: (event: ChangeEvent) => void;
   value?: string;
 }
 


### PR DESCRIPTION
無意間看到的小 typo
另一個可能的 typo - [`clickOutsite`](https://github.com/Yoctol/tailor-ui/search?q=clickOutsite&unscoped_q=clickOutsite)，我猜應該是 `clickOutside` ? 但這可能會 break 一些東西所以我就沒改了～