### PR TITLE
fix(Icon): prevent show tooltips on hover SVG

### DIFF
--- a/src/GlobalStyle/index.ts
+++ b/src/GlobalStyle/index.ts
@@ -39,6 +39,10 @@ const GlobalStyle = createGlobalStyle`
     cursor: pointer;
   }
 
+  svg {
+    pointer-events: none;
+  }
+
   ${datePickerStyles}
 `;
 


### PR DESCRIPTION
close #59

https://stackoverflow.com/questions/15068568/how-can-i-prevent-default-tooltips-to-be-shown-hovering-on-svg-elements