### PR TITLE
feat(Switch): add testid tests for Switch

### DIFF
--- a/packages/tailor-ui/src/Switch/__tests__/index.spec.tsx
+++ b/packages/tailor-ui/src/Switch/__tests__/index.spec.tsx
@@ -38,4 +38,10 @@ describe('Switch', () => {
 
     expect(onChange).toBeCalled();
   });
+
+  it('should support data-testid', () => {
+    const { getByTestId } = render(<Switch checked data-testid="my-switch" />);
+
+    expect(getByTestId('my-switch')).toHaveAttribute('checked');
+  });
 });


### PR DESCRIPTION
@jigsawye 

``` 
FAIL  packages/tailor-ui/src/Switch/__tests__/index.spec.tsx
  ● Switch › should support data-testid

    Unable to find an element by: [data-testid="my-switch"]

    <body>
      <div>
        <label
          class="Switch__StyledSwitch-sc-1iz9t7s-0 hfeDcu"
        >
          <input
            checked=""
            type="checkbox"
          />
          <span />
        </label>
      </div>
    </body>
```

`data-testid` should be added on input.