### PR TITLE
fix(upload): filelist component position

### DIFF
--- a/packages/tailor-ui/src/Upload/Upload.tsx
+++ b/packages/tailor-ui/src/Upload/Upload.tsx
@@ -16,6 +16,7 @@ import { LocaleContext } from '../UIProvider';
 
 const FileList = styled.div`
   display: inline-flex;
+  flex: none;
   flex-direction: column;
 `;
 
@@ -226,7 +227,7 @@ const Upload: FunctionComponent<UploadProps> = ({
         onKeyPress={() => {}}
         role="button"
         {...getRootProps()}
-        style={{ display: 'inline-flex' }}
+        style={{ display: 'inline-flex', flex: 'none' }}
         onClick={event => event.preventDefault()}
       >
         <input {...getInputProps()} />
@@ -257,6 +258,7 @@ const Upload: FunctionComponent<UploadProps> = ({
           {text}
         </Button>
       </div>
+      <br />
       {state.files.length > 0 && (
         <FileList>
           {state.files.map(file => (

--- a/packages/tailor-ui/src/Upload/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/packages/tailor-ui/src/Upload/__tests__/__snapshots__/index.spec.tsx.snap
@@ -151,5 +151,6 @@ exports[`Upload should render correctly 1`] = `
       />
     </button>
   </div>
+  <br />
 </div>
 `;


### PR DESCRIPTION
上次改歪掉了

<img width="556" alt="screencapture 2019-03-18 下午3 44 09" src="https://user-images.githubusercontent.com/8567270/54514279-ae505b00-4994-11e9-97ec-e2f42d8d91ed.png">

修正

<img width="338" alt="screencapture 2019-03-18 下午3 37 15" src="https://user-images.githubusercontent.com/8567270/54514281-b01a1e80-4994-11e9-8131-80ad84c50c00.png">
