### PR TITLE
fix(modal): remove unique from useTransition to prevent style override

### DIFF
--- a/packages/tailor-ui/src/Modal/BaseModal.tsx
+++ b/packages/tailor-ui/src/Modal/BaseModal.tsx
@@ -54,7 +54,6 @@ const BaseModal: FunctionComponent<BaseModalProps> = ({
   });
 
   const transitions = useTransition(visible, null, {
-    unique: true,
     from: {
       opacity: 0,
       transform: 'scale(0.9)',


### PR DESCRIPTION
拿掉 unique
不然他用一樣的 key 有時會讓 modal 打開的時候也吃到 leave 的 pointerEvents: none