### PR TITLE
enhance(Tag): escape editable tag

### DIFF
--- a/packages/tailor-ui-lab/src/Tag/Tag.tsx
+++ b/packages/tailor-ui-lab/src/Tag/Tag.tsx
@@ -130,6 +130,11 @@ const Tag: FunctionComponent<TagProps> = ({
                 handleUpdate(event);
               }
             }}
+            onKeyDown={event => {
+              if (event.key === 'Escape') {
+                setEditing(false);
+              }
+            }}
           />
         ) : (
           children


### PR DESCRIPTION
猜測會有使用者在編輯時會使用 <kbd>ESC</kbd> 來跳脫編輯的狀態，雖然有 `otherProps` 可以傳，但是沒有辦法直接 access 到內部的 `editing` 的狀態，感覺這需求是多餘，如果不要可以直接 close。