### PR TITLE
fix(Tag): canClose work correct

### DIFF
--- a/docs/lab/Tag.mdx
+++ b/docs/lab/Tag.mdx
@@ -5,7 +5,7 @@ route: /lab/tag
 ---
 
 import { PropsTable, Playground } from 'docz';
-import { Input, Button, Flex, Box } from 'tailor-ui';
+import { Input, Button, Flex, Box, useModal } from 'tailor-ui';
 import { Tag } from '@tailor-ui/lab';
 
 # Tag
@@ -59,6 +59,29 @@ import { Tag } from '@tailor-ui/lab';
   <Tag closable>Content</Tag>
 </Playground>
 
+### Use with canClose
+
+<Playground>
+  {() => {
+    const modal = useModal();
+
+    return (
+      <Tag
+        closable
+        canClose={() => modal.error({
+          cancelable: true,
+          title: 'Delete this tag?',
+          content: 'Are you sure? it can not be rollback!',
+        })}
+      >
+        DELETE ME
+      </Tag>
+    );
+
+}}
+
+</Playground>
+
 ### Add & Remove Dynamically
 
 <Playground>
@@ -72,7 +95,7 @@ import { Tag } from '@tailor-ui/lab';
           const invalid = values.filter((_, i) => i !== index).includes(value);
 
           return (
-            <Flex flexDirection="column">
+            <Flex key={value} flexDirection="column">
               <Tag
                 key={value}
                 closable

--- a/packages/tailor-ui-lab/src/Tag/Tag.tsx
+++ b/packages/tailor-ui-lab/src/Tag/Tag.tsx
@@ -147,7 +147,7 @@ const Tag: FunctionComponent<TagProps> = ({
             onClick={async event => {
               event.stopPropagation();
 
-              if (canClose && (await !canClose())) {
+              if (canClose && !(await canClose())) {
                 return;
               }
 

--- a/packages/tailor-ui-lab/src/Tag/__tests__/index.spec.tsx
+++ b/packages/tailor-ui-lab/src/Tag/__tests__/index.spec.tsx
@@ -76,7 +76,7 @@ describe('Tag', () => {
     expect(tagA).not.toBeVisible();
   });
 
-  it('should call canClose when close icon is clicked', () => {
+  it('should call canClose when close icon is clicked and still visbile', () => {
     const canClose = jest.fn().mockResolvedValue(false);
 
     const { container, queryByText } = render(
@@ -93,5 +93,24 @@ describe('Tag', () => {
 
     expect(canClose).toBeCalled();
     expect(tag).toBeVisible();
+  });
+
+  it('should call canClose when close icon is clicked and close correct', async () => {
+    const canClose = jest.fn().mockResolvedValue(true);
+
+    const { container, queryByText } = render(
+      <Tag closable canClose={canClose}>
+        Tailor UI
+      </Tag>
+    );
+
+    const closeIcon = container.querySelector('i');
+
+    fireEvent.click(closeIcon);
+
+    const tag = queryByText('Tailor UI');
+
+    expect(canClose).toBeCalled();
+    await (() => expect(tag).not.toBeVisible());
   });
 });


### PR DESCRIPTION
`await` 放在條件語句造成不預期的行為，如下：

Before:
![Kapture 2019-05-16 at 13 01 43](https://user-images.githubusercontent.com/10325111/57828592-92273980-77de-11e9-89cb-9b56afb75d27.gif)

After:
![Kapture 2019-05-16 at 13 00 06](https://user-images.githubusercontent.com/10325111/57828673-d74b6b80-77de-11e9-9a92-e882eff6f6ea.gif)
