### PR TITLE
fix(modal): pass closable to footer

### DIFF
--- a/docs/Modal.mdx
+++ b/docs/Modal.mdx
@@ -327,7 +327,7 @@ const modal = useModal();
 
 </Playground>
 
-##### Set cancelable to true
+##### Set closable to true
 
 <Playground>
   {() => {
@@ -337,7 +337,7 @@ const modal = useModal();
       <Button
         onClick={async function() {
           const confirmed = await modal.error({
-            cancelable: true,
+            closable: true,
             title: 'Danger',
             content: 'Modal windows are sometimes called heavy windows or modal dialogs because they often display a dialog box. User interfaces typically use modal windows to command user awareness and to display emergency states, though interaction designers argue they are ineffective for that use.',
             confirmText: 'Delete',
@@ -380,7 +380,7 @@ const modal = useModal();
 
 | Property    | Type                | Default                                                   | Description                                                                                                                                                                    |
 | ----------- | ------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| cancelable  | boolean             | `true` if call `model.confirm`, otherwise will be `false` | Show cancel button or not                                                                                                                                                      |
+| closable    | boolean             | `true` if call `model.confirm`, otherwise will be `false` | Show cancel button or not                                                                                                                                                      |
 | cancelText  | string              | Cancel                                                    | Text of the Cancel button                                                                                                                                                      |
 | confirmText | string              | Conrim                                                    | Text of the Conrim button                                                                                                                                                      |
 | onCancel    | function            | -                                                         | Specify a function that will be called when the user clicks the Cancel button. The parameter of this function is a function whose execution should include closing the dialog. |

--- a/docs/lab/Tag.mdx
+++ b/docs/lab/Tag.mdx
@@ -69,7 +69,7 @@ import { Tag } from '@tailor-ui/lab';
       <Tag
         closable
         canClose={() => modal.error({
-          cancelable: true,
+          closable: true,
           title: 'Delete this tag?',
           content: 'Are you sure? it can not be rollback!',
         })}
@@ -105,7 +105,7 @@ import { Tag } from '@tailor-ui/lab';
                 invalid={invalid}
                 canClose={() =>
                   modal.error({
-                    cancelable: true,
+                    closable: true,
                     title: 'Delete this tag?',
                     content: 'Are you sure? it can not be rollback!',
                   })

--- a/packages/tailor-ui/src/Modal/BaseModal.tsx
+++ b/packages/tailor-ui/src/Modal/BaseModal.tsx
@@ -68,7 +68,7 @@ export interface BaseModalProps {
   onOpenComplete?: () => void;
   onCloseComplete?: () => void;
   size?: Size;
-  cancelable?: boolean;
+  closable?: boolean;
   statusBar?: StatusType | null;
   visible: boolean;
 }
@@ -79,7 +79,7 @@ const BaseModal: FunctionComponent<BaseModalProps> = ({
   onCancel,
   onOpenComplete,
   onCloseComplete,
-  cancelable = true,
+  closable = true,
   size = 'md',
   statusBar = null,
   ...otherProps
@@ -88,7 +88,7 @@ const BaseModal: FunctionComponent<BaseModalProps> = ({
   const springRef = useRef(null);
 
   useKeydown({
-    listening: cancelable ? visible : false,
+    listening: closable ? visible : false,
     keyCode: ESC_KEY_CODE,
     onKeydown: onCancel,
   });
@@ -135,10 +135,7 @@ const BaseModal: FunctionComponent<BaseModalProps> = ({
     <Stack defaultOrder={StackingOrder.OVERLAY}>
       {stackingOrder => (
         <>
-          <Backdrop
-            visible={visible}
-            onClick={() => cancelable && onCancel()}
-          />
+          <Backdrop visible={visible} onClick={() => closable && onCancel()} />
           {transitions.map(
             ({ item, key, props }) =>
               item && (

--- a/packages/tailor-ui/src/Modal/Footer.tsx
+++ b/packages/tailor-ui/src/Modal/Footer.tsx
@@ -4,7 +4,7 @@ import { Box, Flex } from '../Layout';
 import { Button, ButtonProps } from '../Button';
 
 export interface FooterProps {
-  cancelable?: boolean;
+  closable?: boolean;
   cancelText?: string | null;
   confirmText?: string;
   onConfirm?: () => void;
@@ -14,7 +14,7 @@ export interface FooterProps {
 }
 
 const Footer: FunctionComponent<FooterProps> = ({
-  cancelable = true,
+  closable = true,
   cancelText,
   confirmText,
   onCancel,
@@ -24,7 +24,7 @@ const Footer: FunctionComponent<FooterProps> = ({
 }) => (
   <Flex width="100%">
     <Box ml="auto">
-      {cancelable && (
+      {closable && (
         <Button variant="normal" onClick={onCancel} {...cancelButtonProps}>
           {cancelText}
         </Button>

--- a/packages/tailor-ui/src/Modal/HooksModal.tsx
+++ b/packages/tailor-ui/src/Modal/HooksModal.tsx
@@ -24,7 +24,7 @@ export interface ModalOptions {
   onCancel?: () => void;
   onOpenComplete?: () => void;
   onCloseComplete?: () => void;
-  cancelable?: boolean;
+  closable?: boolean;
 }
 
 export type Trigger = (
@@ -45,7 +45,7 @@ interface ModalOptionsState {
   onCancel: () => void;
   onOpenComplete?: () => void;
   onCloseComplete?: () => void;
-  cancelable: boolean;
+  closable: boolean;
   type: ModalTypes;
 }
 
@@ -54,7 +54,7 @@ const EffectModal: FunctionComponent<EffectModalProps> = ({ triggerRef }) => {
   const [visible, setVisible] = useState(false);
   const [modalOptions, setModalOptions] = useState<ModalOptionsState>({
     type: 'confirm',
-    cancelable: true,
+    closable: true,
     title: '',
     content: '',
     confirmText: '',
@@ -78,7 +78,7 @@ const EffectModal: FunctionComponent<EffectModalProps> = ({ triggerRef }) => {
   const trigger = (options: ModalOptions, type: ModalTypes): Promise<boolean> =>
     new Promise(resolve => {
       const {
-        cancelable = type === 'confirm',
+        closable = type === 'confirm',
         title = '',
         content = '',
         confirmText = locale.Modal.confirmText,
@@ -91,7 +91,7 @@ const EffectModal: FunctionComponent<EffectModalProps> = ({ triggerRef }) => {
 
       setModalOptions({
         type,
-        cancelable,
+        closable,
         title,
         content,
         confirmText,
@@ -131,7 +131,7 @@ const EffectModal: FunctionComponent<EffectModalProps> = ({ triggerRef }) => {
 
   const {
     title,
-    cancelable,
+    closable,
     content,
     cancelText,
     confirmText,
@@ -142,7 +142,7 @@ const EffectModal: FunctionComponent<EffectModalProps> = ({ triggerRef }) => {
 
   return (
     <BaseModal
-      cancelable={cancelable}
+      closable={closable}
       statusBar={type !== 'confirm' ? type : null}
       visible={visible}
       onCancel={onCancel}
@@ -150,13 +150,13 @@ const EffectModal: FunctionComponent<EffectModalProps> = ({ triggerRef }) => {
       <ModalHeader
         icon={icon}
         title={title}
-        closable={cancelable}
+        closable={closable}
         onCancel={onCancel}
       />
       <ModalContent>{content}</ModalContent>
       <FooterWrapper>
         <Footer
-          cancelable={cancelable}
+          closable={closable}
           cancelText={cancelText}
           confirmText={confirmText}
           onCancel={onCancel}

--- a/packages/tailor-ui/src/Modal/Modal.tsx
+++ b/packages/tailor-ui/src/Modal/Modal.tsx
@@ -55,6 +55,7 @@ interface ModalFooterProps extends FooterProps {
 
 const ModalFooter: FunctionComponent<ModalFooterProps> = ({
   footer,
+  closable,
   cancelText,
   confirmText,
   onCancel,
@@ -70,6 +71,7 @@ const ModalFooter: FunctionComponent<ModalFooterProps> = ({
         footer
       ) : (
         <Footer
+          closable={closable}
           cancelText={cancelText || locale.Modal.cancelText}
           confirmText={confirmText || locale.Modal.confirmText}
           onCancel={onCancel}
@@ -105,6 +107,7 @@ const Modal: FunctionComponent<ModalProps> = ({
     <ModalContent>{children}</ModalContent>
     <ModalFooter
       footer={footer}
+      closable={closable}
       cancelText={cancelText}
       confirmText={confirmText}
       onCancel={onCancel}


### PR DESCRIPTION
BREAKING CHANGE: renamed `cancelable` to `closable`