### PR TITLE
Fix slider touch event

### DIFF
--- a/packages/tailor-ui/src/Slider/Slider.tsx
+++ b/packages/tailor-ui/src/Slider/Slider.tsx
@@ -183,6 +183,7 @@ const Slider: FC<SliderProps> = ({
         disabled={disabled}
         onMouseDown={handleSlideStart}
         onTouchStart={handleSlideStart}
+        onTouchEnd={e => e.preventDefault()}
       >
         <StyledSliderBar />
         <StyledSliderActiveBar


### PR DESCRIPTION
不確定是不是個 bug～不是的話我再 close
這小問題是，如果在手機上用點的方式，component 會一直是 active 的情況，log 後發現 `active` 的變化是 `true` -> `false` -> `true`，但理想上應該是 `true` -> `false` 就好了（這是我的想像啦ＸＤ）


這是參考的解法
https://github.com/facebook/react/issues/9809#issuecomment-395607117

修改前：
![ezgif com-gif-maker](https://user-images.githubusercontent.com/12113222/64059076-41eeae80-cbf8-11e9-9dd9-9a26c71cdc64.gif)


修改後：
![Kapture 2019-08-31 at 13 30 12](https://user-images.githubusercontent.com/12113222/64058970-3c906480-cbf6-11e9-810b-12de6273c258.gif)
