### PR TITLE
feat(upload): add props in Button for custom style

### DIFF
--- a/packages/tailor-ui/.size-snapshot.json
+++ b/packages/tailor-ui/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "lib/index.cjs.js": {
-    "bundled": 405000,
-    "minified": 281775,
-    "gzipped": 130896
+    "bundled": 399097,
+    "minified": 277997,
+    "gzipped": 130382
   }
 }

--- a/packages/tailor-ui/src/Upload/Upload.tsx
+++ b/packages/tailor-ui/src/Upload/Upload.tsx
@@ -4,7 +4,7 @@ import { MdCheck, MdClose, MdFileUpload } from 'react-icons/md';
 import { useDropzone } from 'react-dropzone';
 
 import { Box, Flex } from '../Layout';
-import { Button } from '../Button';
+import { Button, ButtonProps } from '../Button';
 import { Icon } from '../Icon';
 import { useLocale } from '../locale';
 
@@ -103,6 +103,7 @@ interface UploadProps {
     uploadedText?: string;
     failedText?: string;
   };
+  buttonProps: ButtonProps;
 }
 
 const START_UPLOADING = 'START_UPLOADING';
@@ -163,6 +164,7 @@ const Upload: FC<UploadProps> = ({
   onClear,
   disabled,
   texts = {},
+  buttonProps,
   ...props
 }) => {
   const { locale } = useLocale();
@@ -251,6 +253,7 @@ const Upload: FC<UploadProps> = ({
 
             open();
           }}
+          {...buttonProps}
         >
           {text}
         </Button>


### PR DESCRIPTION
可以沿用 Button 既有的樣式

```jsx
<Upload
  variant="primary"
  ...others
/>
```