### PR TITLE
fix(modal): adjust icon color of info modal

### DIFF
--- a/packages/tailor-ui/src/Modal/HooksModal.tsx
+++ b/packages/tailor-ui/src/Modal/HooksModal.tsx
@@ -81,12 +81,13 @@ const EffectModal: FC<EffectModalProps> = ({ triggerRef }) => {
 
   const getIcon = useCallback(() => {
     const { type } = modalOptions;
+    const iconColor = type === 'info' ? 'primary' : type;
 
     if (type === 'confirm') {
       return null;
     }
 
-    return <Icon type={type} fill={type} size="32" mr="2" />;
+    return <Icon type={type} fill={iconColor} size="32" mr="2" />;
   }, [modalOptions]);
 
   const trigger = useCallback(


### PR DESCRIPTION
fix https://github.com/Yoctol/kurator/pull/5852#issuecomment-569172494

Info modal 的 icon 顏色應該是 `primary`