### PR TITLE
fix(Tab): adjust z-index value

### DIFF
--- a/packages/tailor-ui-lab/src/Tabs/__tests__/__snapshots__/Tab.spec.tsx.snap
+++ b/packages/tailor-ui-lab/src/Tabs/__tests__/__snapshots__/Tab.spec.tsx.snap
@@ -22,7 +22,7 @@ exports[`Tabs should render correctly 1`] = `
 
 .c4 {
   position: absolute;
-  z-index: 2;
+  z-index: 1;
   bottom: 0;
   width: 100%;
   height: 3px;
@@ -32,7 +32,7 @@ exports[`Tabs should render correctly 1`] = `
 
 .c3 {
   position: absolute;
-  z-index: 10;
+  z-index: 2;
   bottom: 0;
   height: 3px;
   border-radius: 0.25rem;
@@ -237,7 +237,7 @@ exports[`Tabs should render with sizes 1`] = `
 
 .c4 {
   position: absolute;
-  z-index: 2;
+  z-index: 1;
   bottom: 0;
   width: 100%;
   height: 3px;
@@ -247,7 +247,7 @@ exports[`Tabs should render with sizes 1`] = `
 
 .c3 {
   position: absolute;
-  z-index: 10;
+  z-index: 2;
   bottom: 0;
   height: 3px;
   border-radius: 0.25rem;

--- a/packages/tailor-ui-lab/src/Tabs/styles.ts
+++ b/packages/tailor-ui-lab/src/Tabs/styles.ts
@@ -16,7 +16,7 @@ export const StyledTab = styled.a`
 
 export const TabLine = styled(animated.div)`
   position: absolute;
-  z-index: 2;
+  z-index: 1;
   bottom: 0;
   width: 100%;
   height: 3px;
@@ -26,7 +26,7 @@ export const TabLine = styled(animated.div)`
 
 export const TabActiveLine = styled(animated.div)`
   position: absolute;
-  z-index: 10;
+  z-index: 2;
   bottom: 0;
   height: 3px;
   border-radius: ${p => p.theme.radii.base};


### PR DESCRIPTION
<img width="1416" alt="螢幕快照 2020-01-08 下午3 22 22" src="https://user-images.githubusercontent.com/10325111/71961236-eb425280-3231-11ea-8fa5-63be755609d5.png">

在 Creator 遇到的情況，看了一下實作應該是 Tab component 的 `z-index` 的值設定太大了？

---

Portal 的 z-index：
https://github.com/Yoctol/tailor-ui/blob/98cf7a423a98f9d6790f8289e7b42f4efbc0b779/packages/tailor-ui/src/Portal/Portal.tsx#L53

這裡疊了兩層：
<img width="531" alt="螢幕快照 2020-01-08 下午4 22 32" src="https://user-images.githubusercontent.com/10325111/71961875-4aed2d80-3233-11ea-9d60-fa112e4ce4b4.png">
