### PR TITLE
refactor(select): update typing

### DIFF
--- a/packages/tailor-ui/src/Select/Select.tsx
+++ b/packages/tailor-ui/src/Select/Select.tsx
@@ -1,7 +1,7 @@
 import Downshift from 'downshift';
 import React, {
-  FC,
   FocusEventHandler,
+  PropsWithChildren,
   ReactNode,
   useCallback,
   useEffect,
@@ -19,12 +19,16 @@ import ClearIcon from './ClearIcon';
 import MultiDownshift from './MultiDownshift';
 import SelectArrow from './SelectArrow';
 import SelectInput from './SelectInput';
-import SelectOptions, { CreateOption, Option } from './SelectOptions';
+import SelectOptions, {
+  CreateOption,
+  Option,
+  SelectedValue,
+} from './SelectOptions';
 import SelectedOption from './SelectedOption';
 import { Loading, SelectWrapper, StyledSelect } from './styles';
 import { getDataTestId, itemToString } from './utils';
 
-export interface SelectProps {
+export interface SelectProps<V extends SelectedValue = SelectedValue> {
   id?: string;
   name?: string;
   className?: string;
@@ -37,13 +41,13 @@ export interface SelectProps {
   multiple?: boolean;
   searchable?: boolean;
   options: Option[];
-  value?: Option | Option[];
-  defaultValue?: Option | Option[];
+  value?: V;
+  defaultValue?: V;
   placeholder?: string;
   menu?: ReactNode;
   itemSize?: number;
   optionsMaxHeight?: number;
-  onChange?: (option: Option | Option[]) => void;
+  onChange?: (option: V) => void;
   onBlur?: FocusEventHandler<HTMLInputElement>;
   noOptionsMessage?: () => ReactNode;
   formatCreateLabel?: (labelInfo: {
@@ -56,7 +60,7 @@ export interface SelectProps {
   'data-testid'?: string;
 }
 
-const Select: FC<SelectProps> = ({
+const Select = <V extends SelectedValue>({
   id,
   width = 240,
   size = 'md',
@@ -80,7 +84,7 @@ const Select: FC<SelectProps> = ({
   onCreateOption,
   onBlur,
   ...props
-}) => {
+}: PropsWithChildren<SelectProps<V>>) => {
   const [invalid, labelId, setValue] = useFormField({
     id,
     value,
@@ -99,7 +103,7 @@ const Select: FC<SelectProps> = ({
   }, [visible]);
 
   const handleChange = useCallback(
-    (selection: Option | CreateOption) => {
+    (selection: V | CreateOption) => {
       if (inputRef.current && !multiple) {
         inputRef.current.blur();
       }
@@ -112,8 +116,8 @@ const Select: FC<SelectProps> = ({
       }
 
       if (!isCreate && onChange) {
-        onChange(selection as Option);
-        setValue(selection as Option);
+        onChange(selection as V);
+        setValue(selection);
       }
 
       if (!multiple || isCreate) {

--- a/packages/tailor-ui/src/Select/SelectOptions.tsx
+++ b/packages/tailor-ui/src/Select/SelectOptions.tsx
@@ -20,10 +20,12 @@ import { fuzzyFilter, getDataTestId, itemToString } from './utils';
 export type Option =
   | {
       label: string;
-      value: string;
+      value: string | number;
     }
   | string
   | number;
+
+export type SelectedValue = Option | Option[];
 
 export interface CreateOption {
   label: 'CREATE_OPTION';

--- a/packages/tailor-ui/src/Select/__tests__/Select.spec.tsx
+++ b/packages/tailor-ui/src/Select/__tests__/Select.spec.tsx
@@ -20,8 +20,8 @@ const DEFAULT_OPTIONS = [
 
 const DEFAULT_SELECT_OPTION = { label: 'Banana', value: 'banana' };
 
-const ControlSelect = (props: any) => {
-  const [value, setValue] = useState<any>(DEFAULT_SELECT_OPTION);
+const ControlSelect = (props: Record<string, any>) => {
+  const [value, setValue] = useState(DEFAULT_SELECT_OPTION);
 
   return (
     <Select
@@ -48,7 +48,7 @@ describe('Select', () => {
     const select = getByTestId('select');
     fireEvent.click(select);
 
-    expect(queryByTestId('select-menu')).not.toBeInTheDocument();
+    expect(queryByTestId('select-menu')).toBeNull();
   });
 
   it('should not open menu when loading', () => {
@@ -59,7 +59,7 @@ describe('Select', () => {
     const select = getByTestId('select');
     fireEvent.click(select);
 
-    expect(queryByTestId('select-menu')).not.toBeInTheDocument();
+    expect(queryByTestId('select-menu')).toBeNull();
   });
 
   it('should change value correctly when click option', async () => {
@@ -106,8 +106,8 @@ describe('Select', () => {
       fireEvent.click(orange);
 
       expect(getByTestId('select-item-0')).toHaveTextContent('Orange');
-      expect(queryByTestId('select-item-1')).not.toBeInTheDocument();
-      expect(queryByText('Banana')).not.toBeInTheDocument();
+      expect(queryByTestId('select-item-1')).toBeNull();
+      expect(queryByText('Banana')).toBeNull();
     });
   });
 
@@ -115,7 +115,7 @@ describe('Select', () => {
     it('should create successfully when pass creatable', async () => {
       const CreatableSelect = () => {
         const [loading, setLoading] = useState(false);
-        const [value, setValue] = useState<any>(DEFAULT_SELECT_OPTION);
+        const [value, setValue] = useState(DEFAULT_SELECT_OPTION);
         const [options, setOptions] = useState(DEFAULT_OPTIONS);
 
         return (
@@ -171,7 +171,7 @@ describe('Select', () => {
 
       jest.runOnlyPendingTimers();
 
-      await wait(() => expect(queryByTitle('loading')).not.toBeInTheDocument());
+      await wait(() => expect(queryByTitle('loading')).toBeNull());
       expect(input.value).toBe('XXXXXX');
 
       jest.useRealTimers();
@@ -179,7 +179,7 @@ describe('Select', () => {
 
     it('should not creatable when option is not valid', async () => {
       const CreatableSelect = () => {
-        const [value, setValue] = useState<any>(DEFAULT_SELECT_OPTION);
+        const [value, setValue] = useState(DEFAULT_SELECT_OPTION);
 
         return (
           <Select
@@ -217,7 +217,7 @@ describe('Select', () => {
   describe('clearable', () => {
     it('should clear value when click clear icon', async () => {
       const ClearableSelect = () => {
-        const [value, setValue] = useState<any>(DEFAULT_SELECT_OPTION);
+        const [value, setValue] = useState(DEFAULT_SELECT_OPTION);
 
         return (
           <Select
@@ -264,7 +264,7 @@ describe('Select', () => {
           width="360px"
           multiple
           value={value}
-          onChange={newValue => setValue(newValue as any)}
+          onChange={newValue => setValue(newValue)}
           options={options}
           isValidNewOption={name =>
             !options.map(option => option.label).includes(name) &&
@@ -311,9 +311,7 @@ describe('Select', () => {
 
       fireEvent.click(select);
 
-      await wait(() =>
-        expect(queryByTestId('select-menu')).not.toBeInTheDocument()
-      );
+      await wait(() => expect(queryByTestId('select-menu')).toBeNull());
       expect(getByText('Apple')).toBeInTheDocument();
       expect(getByText('Mango')).toBeInTheDocument();
     });
@@ -326,8 +324,8 @@ describe('Select', () => {
 
       const select = getByTestId('select');
 
-      expect(utilsQueryByText(select, 'Banana')).not.toBeInTheDocument();
-      expect(utilsQueryByText(select, 'Orange')).not.toBeInTheDocument();
+      expect(utilsQueryByText(select, 'Banana')).toBeNull();
+      expect(utilsQueryByText(select, 'Orange')).toBeNull();
     });
 
     it('should remove last selected option when press backspace ', async () => {
@@ -348,12 +346,10 @@ describe('Select', () => {
 
       fireEvent.click(select);
 
-      await wait(() =>
-        expect(queryByTestId('select-menu')).not.toBeInTheDocument()
-      );
+      await wait(() => expect(queryByTestId('select-menu')).toBeNull());
 
       expect(utilsGetByText(select, 'Banana')).toBeInTheDocument();
-      expect(queryByText('Orange')).not.toBeInTheDocument();
+      expect(queryByText('Orange')).toBeNull();
     });
   });
 });

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -4,7 +4,7 @@ import '@babel/polyfill';
 import 'jest-styled-components';
 
 // add some helpful assertions
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 
 const originalError = console.error;
 const originalWarn = console.warn;

--- a/yarn.lock
+++ b/yarn.lock
@@ -881,7 +881,14 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.2", "@babel/runtime@^7.4.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.4", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.3.tgz#0811944f73a6c926bb2ad35e918dcc1bfab279f1"
+  integrity sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
   integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
@@ -5212,7 +5219,7 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
+debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -5265,11 +5272,6 @@ deep-equal@^1.0.1:
     object-is "^1.0.1"
     object-keys "^1.1.1"
     regexp.prototype.flags "^1.2.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -5408,11 +5410,6 @@ detect-indent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
-
-detect-libc@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
-  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^3.0.0:
   version "3.1.0"
@@ -7614,7 +7611,7 @@ husky@^4.2.1:
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -7781,7 +7778,7 @@ inherits@2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
-ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
+ini@^1.3.2, ini@^1.3.4, ini@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
@@ -10041,15 +10038,6 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
-needle@^2.2.1:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
-  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
-  dependencies:
-    debug "^3.2.6"
-    iconv-lite "^0.4.4"
-    sax "^1.2.4"
-
 negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
@@ -10173,22 +10161,6 @@ node-notifier@^6.0.0:
     shellwords "^0.1.1"
     which "^1.3.1"
 
-node-pre-gyp@*:
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
-  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4.4.2"
-
 node-releases@^1.1.29, node-releases@^1.1.47:
   version "1.1.47"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.47.tgz#c59ef739a1fd7ecbd9f0b7cf5b7871e8a8b591e4"
@@ -10294,7 +10266,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.6, npm-packlist@^1.4.4:
+npm-packlist@^1.4.4:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.8.tgz#56ee6cc135b9f98ad3d51c1c95da22bbb9b2ef3e"
   integrity sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==
@@ -10326,7 +10298,7 @@ npm-run-path@^4.0.0:
   dependencies:
     path-key "^3.0.0"
 
-npmlog@^4.0.2, npmlog@^4.1.2:
+npmlog@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -12184,16 +12156,6 @@ rc-util@^4.0.4, rc-util@^4.1.1, rc-util@^4.15.3, rc-util@^4.4.0:
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.1.0"
 
-rc@^1.2.7:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-autosize-textarea@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/react-autosize-textarea/-/react-autosize-textarea-7.0.0.tgz#4f633e4238de7ba73c1da8fdc307353c50f1c5ab"
@@ -13033,7 +12995,7 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -13242,7 +13204,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -13995,7 +13957,7 @@ strip-indent@^3.0.0:
   dependencies:
     min-indent "^1.0.0"
 
-strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
@@ -14277,7 +14239,7 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.2, tar@^4.4.8:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==


### PR DESCRIPTION
## Summary

用 generic type 這樣就不會一直 as 了

## Test plan

現在 Select 的問題是有兩種使用情境，單選跟多選
然後 option 有三種形式：
- `number`
- `string`
- `{ label: string; value: string }`

原本的 type 寫法會導致在用的時候，不知道 onChange 拿到的 value 是什麼 type，所以都要用 as 來強轉型別
改成 generic 之後，onChange 拿到的 value 就會跟傳入的 value / defaultValue 一樣