### PR TITLE
refactor: move checkbox group & radio group out of its base component

### DIFF
--- a/docs/Checkbox.md
+++ b/docs/Checkbox.md
@@ -13,7 +13,7 @@ Checkbox component.
 ## Examples
 
 ```js
-import { Checkbox } from 'tailor-ui';
+import { Checkbox, CheckboxGroup } from 'tailor-ui';
 ```
 
 ### Checkbox
@@ -61,7 +61,7 @@ import { Checkbox } from 'tailor-ui';
 </>
 ```
 
-### Checkbox.Group
+### CheckboxGroup
 
 #### Basic
 
@@ -71,7 +71,7 @@ import { Checkbox } from 'tailor-ui';
 
   return (
     <>
-      <Checkbox.Group
+      <CheckboxGroup
         options={[
           { label: 'checkbox 1', value: 'check_1' },
           { label: 'checkbox 2', value: 'check_2' },
@@ -82,7 +82,7 @@ import { Checkbox } from 'tailor-ui';
         onChange={set}
       />
       <br />
-      <Checkbox.Group
+      <CheckboxGroup
         options={[
           { label: 'checkbox 1', value: 'check_1' },
           { label: 'checkbox 2', value: 'check_2' },
@@ -105,7 +105,7 @@ import { Checkbox } from 'tailor-ui';
 
   return (
     <>
-      <Checkbox.Group
+      <CheckboxGroup
         options={[
           { label: 'checkbox 1', value: 'check_1' },
           { label: 'checkbox 2', value: 'check_2' },
@@ -135,7 +135,7 @@ import { Checkbox } from 'tailor-ui';
 
   return (
     <>
-      <Checkbox.Group value={value} onChange={set}>
+      <CheckboxGroup value={value} onChange={set}>
         <Box bg="gray300" p="2" m="2">
           <Checkbox value="check_1">checkbox 1</Checkbox>
         </Box>
@@ -148,9 +148,9 @@ import { Checkbox } from 'tailor-ui';
         <Box bg="gray300" p="2" m="2">
           <Checkbox value="check_4">checkbox 4</Checkbox>
         </Box>
-      </Checkbox.Group>
+      </CheckboxGroup>
       <br />
-      <Checkbox.Group defaultValue={['check_1']} onChange={console.log}>
+      <CheckboxGroup defaultValue={['check_1']} onChange={console.log}>
         <Box bg="gray300" p="2" m="2">
           <Checkbox value="check_1">checkbox 1</Checkbox>
         </Box>
@@ -163,7 +163,7 @@ import { Checkbox } from 'tailor-ui';
         <Box bg="gray300" p="2" m="2">
           <Checkbox value="check_4">checkbox 4</Checkbox>
         </Box>
-      </Checkbox.Group>
+      </CheckboxGroup>
     </>
   );
 }
@@ -176,7 +176,7 @@ import { Checkbox } from 'tailor-ui';
   const [value, set] = useState([]);
 
   return (
-    <Checkbox.Group
+    <CheckboxGroup
       direction="vertical"
       options={[
         { label: 'checkbox 1', value: 'check_1' },
@@ -201,7 +201,7 @@ import { Checkbox } from 'tailor-ui';
     value && value.length !== 4 ? 'Should checked all check box' : null
   }
 >
-  <Checkbox.Group
+  <CheckboxGroup
     defaultValue={['check_1']}
     options={[
       { label: 'checkbox 1', value: 'check_1' },
@@ -228,7 +228,7 @@ import { Checkbox } from 'tailor-ui';
 | `onFocus`        |                                                                      | `(event: FocusEvent) => void`  |         |
 | `onBlur`         |                                                                      | `(event: FocusEvent) => void`  |         |
 
-### Checkbox.Group
+### CheckboxGroup
 
 | Property       | Description                                                    | Type                                                         | Default |
 | -------------- | -------------------------------------------------------------- | ------------------------------------------------------------ | ------- |

--- a/docs/Drawer.md
+++ b/docs/Drawer.md
@@ -48,12 +48,12 @@ import { Drawer } from 'tailor-ui';
 
   return (
     <>
-      <Radio.Group value={placement} onChange={setPlacement}>
+      <RadioGroup value={placement} onChange={setPlacement}>
         <Radio value="top">Top</Radio>
         <Radio value="right">Right (default)</Radio>
         <Radio value="bottom">Bottom</Radio>
         <Radio value="left">Left</Radio>
-      </Radio.Group>
+      </RadioGroup>
 
       <Button mt="3" onClick={() => setVisible(!visible)}>
         Open

--- a/docs/Radio.md
+++ b/docs/Radio.md
@@ -13,7 +13,7 @@ Radio.
 ## Examples
 
 ```js
-import { Radio } from 'tailor-ui';
+import { Radio, RadioGroup } from 'tailor-ui';
 ```
 
 ### Radio
@@ -54,7 +54,7 @@ import { Radio } from 'tailor-ui';
 </>
 ```
 
-### Radio.Group
+### RadioGroup
 
 #### Basic
 
@@ -64,7 +64,7 @@ import { Radio } from 'tailor-ui';
 
   return (
     <>
-      <Radio.Group
+      <RadioGroup
         options={[
           { label: 'Radio A', value: 'radio-a' },
           { label: 'Radio B', value: 'radio-b' },
@@ -75,7 +75,7 @@ import { Radio } from 'tailor-ui';
         onChange={setValue}
       />
       <br />
-      <Radio.Group
+      <RadioGroup
         options={[
           { label: 'Radio A', value: 'radio-a' },
           { label: 'Radio B', value: 'radio-b' },
@@ -98,7 +98,7 @@ import { Radio } from 'tailor-ui';
 
   return (
     <>
-      <Radio.Group
+      <RadioGroup
         options={[
           { label: 'Radio A', value: 'radio-a' },
           { label: 'Radio B', value: 'radio-b' },
@@ -123,7 +123,7 @@ import { Radio } from 'tailor-ui';
 
   return (
     <>
-      <Radio.Group value={value} onChange={setValue}>
+      <RadioGroup value={value} onChange={setValue}>
         <Box bg="gray300" p="2" m="2">
           <Radio value="radio_1">radio 1</Radio>
         </Box>
@@ -136,9 +136,9 @@ import { Radio } from 'tailor-ui';
         <Box bg="gray300" p="2" m="2">
           <Radio value="radio_4">radio 4</Radio>
         </Box>
-      </Radio.Group>
+      </RadioGroup>
       <br />
-      <Radio.Group defaultValue="radio_1" onChange={console.log}>
+      <RadioGroup defaultValue="radio_1" onChange={console.log}>
         <Box bg="gray300" p="2" m="2">
           <Radio value="radio_1">radio 1</Radio>
         </Box>
@@ -151,7 +151,7 @@ import { Radio } from 'tailor-ui';
         <Box bg="gray300" p="2" m="2">
           <Radio value="radio_4">radio 4</Radio>
         </Box>
-      </Radio.Group>
+      </RadioGroup>
     </>
   );
 }
@@ -164,7 +164,7 @@ import { Radio } from 'tailor-ui';
   const [value, setValue] = useState('');
 
   return (
-    <Radio.Group
+    <RadioGroup
       direction="vertical"
       options={[
         { label: 'radio 1', value: 'radio_1' },
@@ -187,7 +187,7 @@ import { Radio } from 'tailor-ui';
   label="Yes or No?"
   validator={value => (value !== 'yes' ? 'Should press yes' : null)}
 >
-  <Radio.Group
+  <RadioGroup
     defaultValue="no"
     options={[
       { label: 'Yes', value: 'yes' },
@@ -213,7 +213,7 @@ import { Radio } from 'tailor-ui';
 | `onFocus`        |                                                                   | `(event: FocusEvent) => void`  |         |
 | `onBlur`         |                                                                   | `(event: FocusEvent) => void`  |         |
 
-### Radio.Group
+### RadioGroup
 
 | Property       | Description                                                    | Type                                                         | Default |
 |----------------|----------------------------------------------------------------|--------------------------------------------------------------|---------|

--- a/docs/UIProvider.md
+++ b/docs/UIProvider.md
@@ -31,10 +31,10 @@ ReactDOM.render(
 
   return (
     <>
-      <Radio.Group value={value} onChange={setValue}>
+      <RadioGroup value={value} onChange={setValue}>
         <Radio value="en_US">English</Radio>
         <Radio value="zh_Hant">正體中文</Radio>
-      </Radio.Group>
+      </RadioGroup>
 
       <Box mt="3">
         <UIProvider locale={locales[value]}>

--- a/packages/tailor-ui-formik/src/CheckboxField/CheckboxField.tsx
+++ b/packages/tailor-ui-formik/src/CheckboxField/CheckboxField.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { useField } from 'formik';
 
-import { Checkbox, CheckboxGroupProps, FormField } from 'tailor-ui';
+import { CheckboxGroup, CheckboxGroupProps, FormField } from 'tailor-ui';
 import { mergeEventProps } from '@tailor-ui/utils';
 
 export interface CheckboxFieldProps extends CheckboxGroupProps {
@@ -26,7 +26,7 @@ const CheckboxField: FC<CheckboxFieldProps> = ({
       label={fieldLabel}
       validationMessage={meta.error && meta.touched ? meta.error : null}
     >
-      <Checkbox.Group
+      <CheckboxGroup
         direction={direction}
         value={field.value}
         options={options}

--- a/packages/tailor-ui-formik/src/RadioField/RadioField.tsx
+++ b/packages/tailor-ui-formik/src/RadioField/RadioField.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { useField } from 'formik';
 
-import { FormField, Radio, RadioGroupProps } from 'tailor-ui';
+import { FormField, RadioGroup, RadioGroupProps } from 'tailor-ui';
 import { mergeEventProps } from '@tailor-ui/utils';
 
 export interface RadioProps extends RadioGroupProps {
@@ -26,7 +26,7 @@ const RadioField: FC<RadioProps> = ({
       label={fieldLabel}
       validationMessage={meta.error && meta.touched ? meta.error : null}
     >
-      <Radio.Group
+      <RadioGroup
         direction={direction}
         value={field.value}
         options={options}

--- a/packages/tailor-ui/src/Checkbox/Checkbox.tsx
+++ b/packages/tailor-ui/src/Checkbox/Checkbox.tsx
@@ -1,9 +1,10 @@
 import React, {
   ChangeEventHandler,
-  FC,
   FocusEventHandler,
+  MouseEventHandler,
+  ReactNode,
+  forwardRef,
   useContext,
-  useMemo,
 } from 'react';
 
 import { Box } from '../Layout';
@@ -11,19 +12,14 @@ import { useFormField } from '../FormField';
 
 import { CheckboxContext } from './CheckboxContext';
 import {
-  CheckboxGroup,
-  CheckboxGroupProps as _CheckboxGroupProps,
-} from './CheckboxGroup';
-import {
   CheckboxInner,
   CheckboxLabel,
   CheckboxWrapper,
   StyledCheckbox,
 } from './styles';
 
-export type CheckboxGroupProps = _CheckboxGroupProps;
-
 export interface CheckboxProps {
+  children?: ReactNode;
   checked?: boolean;
   defaultChecked?: boolean;
   disabled?: boolean;
@@ -32,37 +28,43 @@ export interface CheckboxProps {
   id?: string;
   onFocus?: FocusEventHandler<HTMLInputElement>;
   onBlur?: FocusEventHandler<HTMLInputElement>;
+  onMouseEnter?: MouseEventHandler<HTMLLabelElement>;
+  onMouseLeave?: MouseEventHandler<HTMLLabelElement>;
 }
 
-const Checkbox: FC<CheckboxProps> & {
-  Group: typeof CheckboxGroup;
-} = ({
-  children,
-  disabled = false,
-  checked,
-  defaultChecked,
-  onChange,
-  value,
-  id,
-  ...props
-}) => {
+const Checkbox = forwardRef<HTMLLabelElement, CheckboxProps>(function Checkbox(
+  {
+    children,
+    disabled = false,
+    checked,
+    defaultChecked,
+    onChange,
+    value,
+    id,
+    onMouseEnter,
+    onMouseLeave,
+    ...props
+  },
+  ref
+) {
   const { handleChange, isChecked, direction } = useContext(CheckboxContext);
-
-  const inGroup = Boolean(handleChange);
-
-  const boxChecked = useMemo(
-    () => (isChecked && value ? isChecked(value) : checked),
-    [checked, isChecked, value]
-  );
-
   const [, labelId, setValue] = useFormField({
     id,
     value: checked,
     defaultValue: defaultChecked,
   });
 
+  const inGroup = Boolean(handleChange);
+  const boxChecked = isChecked && value ? isChecked(value) : checked;
+
   return (
-    <CheckboxLabel disabled={disabled} direction={direction}>
+    <CheckboxLabel
+      ref={ref}
+      disabled={disabled}
+      direction={direction}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       <CheckboxWrapper>
         <StyledCheckbox
           id={inGroup ? undefined : labelId}
@@ -87,8 +89,6 @@ const Checkbox: FC<CheckboxProps> & {
       <Box px="2">{children}</Box>
     </CheckboxLabel>
   );
-};
-
-Checkbox.Group = CheckboxGroup;
+});
 
 export { Checkbox };

--- a/packages/tailor-ui/src/Checkbox/__tests__/CheckboxGrouo.spec.tsx
+++ b/packages/tailor-ui/src/Checkbox/__tests__/CheckboxGrouo.spec.tsx
@@ -4,13 +4,14 @@ import { fireEvent, render } from 'test/test-utils';
 
 import { Box } from '../../Layout';
 import { Checkbox } from '../Checkbox';
+import { CheckboxGroup } from '../CheckboxGroup';
 
-describe('Checkbox.Group', () => {
+describe('CheckboxGroup', () => {
   it('should render disabled checkbox if option set disabled as true', () => {
     const onChange = jest.fn();
 
     const { container } = render(
-      <Checkbox.Group
+      <CheckboxGroup
         direction="vertical"
         options={[
           { label: 'checkbox 1', value: 'check_1', disabled: true },
@@ -31,7 +32,7 @@ describe('Checkbox.Group', () => {
     const onChange = jest.fn();
 
     const { container } = render(
-      <Checkbox.Group
+      <CheckboxGroup
         direction="vertical"
         options={[
           { label: 'checkbox 1', value: 'check_1' },
@@ -54,7 +55,7 @@ describe('Checkbox.Group', () => {
 
   it('should render vertical checkbox group', () => {
     const { container } = render(
-      <Checkbox.Group
+      <CheckboxGroup
         direction="vertical"
         options={[
           { label: 'checkbox 1', value: 'check_1' },
@@ -71,7 +72,7 @@ describe('Checkbox.Group', () => {
   describe('composition with Checkbox', () => {
     it('should render correctly', () => {
       const { container } = render(
-        <Checkbox.Group value={[]}>
+        <CheckboxGroup value={[]}>
           <Box>
             <Checkbox value="check_1">checkbox 1</Checkbox>
           </Box>
@@ -81,7 +82,7 @@ describe('Checkbox.Group', () => {
           <Box>
             <Checkbox value="check_3">checkbox 3</Checkbox>
           </Box>
-        </Checkbox.Group>
+        </CheckboxGroup>
       );
 
       expect(container.firstChild).toMatchSnapshot();
@@ -91,7 +92,7 @@ describe('Checkbox.Group', () => {
       const onChange = jest.fn();
 
       const { container } = render(
-        <Checkbox.Group value={[]} onChange={onChange}>
+        <CheckboxGroup value={[]} onChange={onChange}>
           <Box>
             <Checkbox value="check_1">checkbox 1</Checkbox>
           </Box>
@@ -101,7 +102,7 @@ describe('Checkbox.Group', () => {
           <Box>
             <Checkbox value="check_3">checkbox 3</Checkbox>
           </Box>
-        </Checkbox.Group>
+        </CheckboxGroup>
       );
 
       const checkbox = container.querySelector(

--- a/packages/tailor-ui/src/Checkbox/__tests__/__snapshots__/CheckboxGrouo.spec.tsx.snap
+++ b/packages/tailor-ui/src/Checkbox/__tests__/__snapshots__/CheckboxGrouo.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Checkbox.Group composition with Checkbox should render correctly 1`] = `
+exports[`CheckboxGroup composition with Checkbox should render correctly 1`] = `
 .c1 {
   box-sizing: border-box;
 }
@@ -190,7 +190,7 @@ exports[`Checkbox.Group composition with Checkbox should render correctly 1`] = 
 </div>
 `;
 
-exports[`Checkbox.Group should render vertical checkbox group 1`] = `
+exports[`CheckboxGroup should render vertical checkbox group 1`] = `
 .c7 {
   box-sizing: border-box;
   padding-left: 0.5rem;

--- a/packages/tailor-ui/src/Checkbox/index.ts
+++ b/packages/tailor-ui/src/Checkbox/index.ts
@@ -1,1 +1,2 @@
 export * from './Checkbox';
+export * from './CheckboxGroup';

--- a/packages/tailor-ui/src/Radio/Radio.tsx
+++ b/packages/tailor-ui/src/Radio/Radio.tsx
@@ -1,21 +1,20 @@
 import React, {
   ChangeEventHandler,
-  FC,
   FocusEventHandler,
+  MouseEventHandler,
+  ReactNode,
+  forwardRef,
   useContext,
-  useMemo,
 } from 'react';
 
 import { Box } from '../Layout';
 import { useFormField } from '../FormField';
 
 import { RadioContext } from './RadioContext';
-import { RadioGroup, RadioGroupProps as _RadioGroupProps } from './RadioGroup';
 import { RadioInner, RadioLabel, RadioWrapper, StyledRadio } from './styles';
 
-export type RadioGroupProps = _RadioGroupProps;
-
 export interface RadioProps {
+  children?: ReactNode;
   checked?: boolean;
   defaultChecked?: boolean;
   disabled?: boolean;
@@ -23,35 +22,41 @@ export interface RadioProps {
   value?: string;
   onFocus?: FocusEventHandler<HTMLInputElement>;
   onBlur?: FocusEventHandler<HTMLInputElement>;
+  onMouseEnter?: MouseEventHandler<HTMLLabelElement>;
+  onMouseLeave?: MouseEventHandler<HTMLLabelElement>;
 }
 
-const Radio: FC<RadioProps> & {
-  Group: typeof RadioGroup;
-} = ({
-  children,
-  disabled = false,
-  checked,
-  defaultChecked,
-  onChange,
-  value,
-  ...props
-}) => {
+const Radio = forwardRef<HTMLLabelElement, RadioProps>(function Radio(
+  {
+    children,
+    disabled = false,
+    checked,
+    defaultChecked,
+    onChange,
+    value,
+    onMouseEnter,
+    onMouseLeave,
+    ...props
+  },
+  ref
+) {
   const { handleChange, isChecked, direction } = useContext(RadioContext);
-
-  const inGroup = Boolean(handleChange);
-
-  const boxChecked = useMemo(
-    () => (isChecked && value ? isChecked(value) : checked),
-    [checked, isChecked, value]
-  );
-
   const [, , setValue] = useFormField({
     value: checked,
     defaultValue: defaultChecked,
   });
 
+  const inGroup = Boolean(handleChange);
+  const boxChecked = isChecked && value ? isChecked(value) : checked;
+
   return (
-    <RadioLabel disabled={disabled} direction={direction}>
+    <RadioLabel
+      ref={ref}
+      disabled={disabled}
+      direction={direction}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
       <RadioWrapper>
         <StyledRadio
           disabled={disabled}
@@ -75,8 +80,6 @@ const Radio: FC<RadioProps> & {
       <Box px="2">{children}</Box>
     </RadioLabel>
   );
-};
-
-Radio.Group = RadioGroup;
+});
 
 export { Radio };

--- a/packages/tailor-ui/src/Radio/RadioGroup.tsx
+++ b/packages/tailor-ui/src/Radio/RadioGroup.tsx
@@ -1,14 +1,15 @@
-import React, { FC, ReactNode, useCallback, useMemo } from 'react';
+import React, { ReactNode, forwardRef, useCallback, useMemo } from 'react';
 
 import { useOwnValue } from '@tailor-ui/hooks';
 
 import { useFormField } from '../FormField';
 
 import { Direction, RadioContext } from './RadioContext';
-import { Radio, RadioProps } from './Radio';
+import { Radio } from './Radio';
 import { RadioGroupFlex } from './styles';
 
-export interface RadioGroupProps extends Omit<RadioProps, 'onChange'> {
+export interface RadioGroupProps {
+  children?: ReactNode;
   defaultValue?: string;
   direction?: Direction;
   options?: {
@@ -20,66 +21,68 @@ export interface RadioGroupProps extends Omit<RadioProps, 'onChange'> {
   onChange?: (value: string) => void;
 }
 
-const RadioGroup: FC<RadioGroupProps> = ({
-  value,
-  defaultValue,
-  options = null,
-  onChange,
-  direction = 'horizontal',
-  children,
-  ...otherProps
-}) => {
-  const [ownValue, setOwnValue] = useOwnValue(
+const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
+  function RadioGroup(
     {
       value,
       defaultValue,
+      options = null,
       onChange,
+      direction = 'horizontal',
+      children,
+      ...otherProps
     },
-    { fallbackValue: '' }
-  );
+    ref
+  ) {
+    const [ownValue, setOwnValue] = useOwnValue(
+      {
+        value,
+        defaultValue,
+        onChange,
+      },
+      { fallbackValue: '' }
+    );
 
-  const [, , setValue] = useFormField({
-    value: ownValue,
-  });
+    const [, , setValue] = useFormField({
+      value: ownValue,
+    });
 
-  const handleChange = useCallback(
-    newValue => {
-      setOwnValue(newValue);
-      setValue(newValue);
-    },
-    [setOwnValue, setValue]
-  );
+    const handleChange = useCallback(
+      newValue => {
+        setOwnValue(newValue);
+        setValue(newValue);
+      },
+      [setOwnValue, setValue]
+    );
 
-  const isChecked = useCallback(_value => ownValue === _value, [ownValue]);
+    const isChecked = useCallback(_value => ownValue === _value, [ownValue]);
 
-  const radioButtons = useMemo(
-    () =>
-      options
-        ? options.map(({ label, value: optionValue, disabled = false }) => (
-            <Radio
-              key={optionValue}
-              value={optionValue}
-              disabled={disabled}
-              {...otherProps}
-            >
-              {label}
-            </Radio>
-          ))
-        : children,
-    [children, options, otherProps]
-  );
+    const child = useMemo(
+      () =>
+        options
+          ? options.map(({ label, value: optionValue, disabled = false }) => (
+              <Radio key={optionValue} value={optionValue} disabled={disabled}>
+                {label}
+              </Radio>
+            ))
+          : children,
+      [children, options]
+    );
 
-  return (
-    <RadioContext.Provider
-      value={{
-        direction,
-        handleChange,
-        isChecked,
-      }}
-    >
-      <RadioGroupFlex direction={direction}>{radioButtons}</RadioGroupFlex>
-    </RadioContext.Provider>
-  );
-};
+    return (
+      <RadioContext.Provider
+        value={{
+          direction,
+          handleChange,
+          isChecked,
+        }}
+      >
+        <RadioGroupFlex ref={ref} direction={direction} {...otherProps}>
+          {child}
+        </RadioGroupFlex>
+      </RadioContext.Provider>
+    );
+  }
+);
 
 export { RadioGroup };

--- a/packages/tailor-ui/src/Radio/__tests__/RadioGroup.spec.tsx
+++ b/packages/tailor-ui/src/Radio/__tests__/RadioGroup.spec.tsx
@@ -4,13 +4,14 @@ import { fireEvent, render } from 'test/test-utils';
 
 import { Box } from '../../Layout';
 import { Radio } from '../Radio';
+import { RadioGroup } from '../RadioGroup';
 
-describe('Radio.Group', () => {
+describe('RadioGroup', () => {
   it('should render disabled radio if option set disabled as true', () => {
     const onChange = jest.fn();
 
     const { container } = render(
-      <Radio.Group
+      <RadioGroup
         direction="vertical"
         options={[
           { label: 'radio 1', value: 'radio_1', disabled: true },
@@ -31,7 +32,7 @@ describe('Radio.Group', () => {
     const onChange = jest.fn();
 
     const { container } = render(
-      <Radio.Group
+      <RadioGroup
         direction="vertical"
         options={[
           { label: 'radio 1', value: 'radio_1' },
@@ -54,7 +55,7 @@ describe('Radio.Group', () => {
 
   it('should render vertical radio group', () => {
     const { container } = render(
-      <Radio.Group
+      <RadioGroup
         direction="vertical"
         options={[
           { label: 'radio 1', value: 'radio_1' },
@@ -71,7 +72,7 @@ describe('Radio.Group', () => {
   describe('composition with Radio', () => {
     it('should render correctly', () => {
       const { container } = render(
-        <Radio.Group value="">
+        <RadioGroup value="">
           <Box>
             <Radio value="radio_1">Radio 1</Radio>
           </Box>
@@ -81,7 +82,7 @@ describe('Radio.Group', () => {
           <Box>
             <Radio value="radio_3">Radio 3</Radio>
           </Box>
-        </Radio.Group>
+        </RadioGroup>
       );
 
       expect(container.firstChild).toMatchSnapshot();
@@ -91,7 +92,7 @@ describe('Radio.Group', () => {
       const onChange = jest.fn();
 
       const { container } = render(
-        <Radio.Group value="" onChange={onChange}>
+        <RadioGroup value="" onChange={onChange}>
           <Box>
             <Radio value="radio_1">Radio 1</Radio>
           </Box>
@@ -101,7 +102,7 @@ describe('Radio.Group', () => {
           <Box>
             <Radio value="radio_3">Radio 3</Radio>
           </Box>
-        </Radio.Group>
+        </RadioGroup>
       );
 
       const radio1 = container.querySelector(

--- a/packages/tailor-ui/src/Radio/__tests__/__snapshots__/RadioGroup.spec.tsx.snap
+++ b/packages/tailor-ui/src/Radio/__tests__/__snapshots__/RadioGroup.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Radio.Group composition with Radio should render correctly 1`] = `
+exports[`RadioGroup composition with Radio should render correctly 1`] = `
 .c1 {
   box-sizing: border-box;
 }
@@ -185,7 +185,7 @@ exports[`Radio.Group composition with Radio should render correctly 1`] = `
 </div>
 `;
 
-exports[`Radio.Group should render vertical radio group 1`] = `
+exports[`RadioGroup should render vertical radio group 1`] = `
 .c6 {
   box-sizing: border-box;
   padding-left: 0.5rem;

--- a/packages/tailor-ui/src/Radio/index.ts
+++ b/packages/tailor-ui/src/Radio/index.ts
@@ -1,1 +1,2 @@
 export * from './Radio';
+export * from './RadioGroup';

--- a/packages/tailor-ui/src/__tests__/index.spec.ts
+++ b/packages/tailor-ui/src/__tests__/index.spec.ts
@@ -5,6 +5,7 @@ import {
   Button,
   Card,
   Checkbox,
+  CheckboxGroup,
   Container,
   DatePicker,
   Divider,
@@ -22,6 +23,7 @@ import {
   Popconfirm,
   Popover,
   Radio,
+  RadioGroup,
   Select,
   Spin,
   Steps,
@@ -47,7 +49,7 @@ describe('index', () => {
     expect(Button).toBeDefined();
     expect(Card).toBeDefined();
     expect(Checkbox).toBeDefined();
-    expect(Checkbox.Group).toBeDefined();
+    expect(CheckboxGroup).toBeDefined();
     expect(Container).toBeDefined();
     expect(DatePicker).toBeDefined();
     expect(Divider).toBeDefined();
@@ -65,7 +67,7 @@ describe('index', () => {
     expect(Popconfirm).toBeDefined();
     expect(Popover).toBeDefined();
     expect(Radio).toBeDefined();
-    expect(Radio.Group).toBeDefined();
+    expect(RadioGroup).toBeDefined();
     expect(Select).toBeDefined();
     expect(Spin).toBeDefined();
     expect(Steps).toBeDefined();


### PR DESCRIPTION
- 把 Checkbox.Group 跟 Radio.Group 從 Checkbox 及 Radio 移出
- 加上 forwardRef 以支援 Tooltip 的使用

BREAKING CHANGE: You should import CheckboxGroup & RadioGroup instead of Checkbox.Group & Radio.Group