### PR TITLE
refactor(breadcrumb): re-render when parent width is changed

### DIFF
--- a/docs/Breadcrumb.md
+++ b/docs/Breadcrumb.md
@@ -1,0 +1,95 @@
+---
+id: breadcrumb
+title: Breadcrumb
+---
+
+A breadcrumb displays the current location within a hierarchy. It allows going back to states higher up in the hierarchy.
+
+## When To Use
+
+- When the system has more than two layers in a hierarchy.
+- When you need to inform the user of where they are.
+- When the user may need to navigate back to a higher level.
+- When the application has multi-layer architecture.
+
+## Examples
+
+```js
+import { Breadcrumb } from 'tailor-ui';
+```
+
+### Basic
+
+```jsx live
+<Breadcrumb
+  items={[
+    {
+      key: 'dashboard',
+      name: 'Dashboard',
+      onClick: () => {},
+    },
+  ]}
+/>
+```
+
+### handle onClick
+
+```jsx live
+<Breadcrumb
+  items={[
+    {
+      key: '1',
+      name: 'Page 1',
+      onClick: () => {},
+    },
+    {
+      key: '2',
+      name: 'Page 2',
+      onClick: () => {},
+    },
+  ]}
+/>
+```
+
+### Overflow
+
+```jsx live
+  <Breadcrumb
+    items={[
+      {
+        key: '1',
+        name: 'Page 1 is too too long long long long long long long long',
+        onClick: () => {},
+      },
+      {
+        key: '2',
+        name: 'Page 2 is too too long long long long long long long long',
+        onClick: () => {},
+      },
+      {
+        key: '3',
+        name: 'Page 3 is too too long long long long long long long long',
+        onClick: () => {},
+      },
+      {
+        key: '4',
+        name: 'Page 4 is too too long long long long long long long long',
+        onClick: () => {},
+      },
+    ]}
+  />
+```
+
+## API
+
+| Property | Description              | Type       | Default |
+|----------|--------------------------|------------|---------|
+| `items`  | Breadcrumb configuration | Breadcrumb | `[]`    |
+
+### Breadcrumb item
+
+| Property  | Description                             | Type                          | Default |
+|-----------|-----------------------------------------|-------------------------------|---------|
+| `key`     | key                                     | `string`                      |         |
+| `name`    | display name                            | `ReactNode`                   |         |
+| `onClick` | set the handler to handle `click` event | `(event: MouseEvent) => void` |         |

--- a/packages/tailor-ui-hooks/package.json
+++ b/packages/tailor-ui-hooks/package.json
@@ -25,8 +25,10 @@
     "testonly:cov": "jest --coverage --runInBand",
     "testonly:watch": "jest --watch"
   },
+  "sideEffects": false,
   "typings": "lib/index.d.ts",
   "dependencies": {
+    "@reach/utils": "^0.8.0",
     "@tailor-ui/utils": "^0.3.2",
     "lodash.debounce": "^4.0.8",
     "resize-observer-polyfill": "^1.5.1"
@@ -37,6 +39,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "sideEffects": false
+  }
 }

--- a/packages/tailor-ui-hooks/src/useMeasure.ts
+++ b/packages/tailor-ui-hooks/src/useMeasure.ts
@@ -1,10 +1,12 @@
 import ResizeObserver from 'resize-observer-polyfill';
-import { useEffect, useRef, useState } from 'react';
+import { Ref, useEffect, useRef, useState } from 'react';
+import { useForkedRef } from '@reach/utils';
 
 import { tuplify } from '@tailor-ui/utils';
 
-const useMeasure = () => {
-  const ref = useRef<any>(null);
+const useMeasure = (targetRef: Ref<any> = null) => {
+  const measureRef = useRef<any>(null);
+  const ref = useForkedRef(measureRef, targetRef);
 
   const [bounds, set] = useState({
     left: 0,
@@ -18,8 +20,8 @@ const useMeasure = () => {
   );
 
   useEffect(() => {
-    if (ref.current) {
-      ro.observe(ref.current);
+    if (measureRef.current) {
+      ro.observe(measureRef.current);
     }
 
     return () => ro.disconnect();

--- a/packages/tailor-ui/package.json
+++ b/packages/tailor-ui/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.4",
     "@reach/rect": "^0.8.0",
+    "@reach/utils": "^0.8.0",
     "@tailor-ui/hooks": "^0.6.2",
     "@tailor-ui/theme": "^0.4.1",
     "@tailor-ui/utils": "^0.3.2",

--- a/packages/tailor-ui/src/Breadcrumb/__tests__/Breadcrumb.spec.tsx
+++ b/packages/tailor-ui/src/Breadcrumb/__tests__/Breadcrumb.spec.tsx
@@ -1,0 +1,52 @@
+import React, { createRef } from 'react';
+
+import { fireEvent, render } from 'test/test-utils';
+
+import { Breadcrumb } from '../Breadcrumb';
+
+describe('Breadcrumb', () => {
+  // FIXME: the jsdom does not render real dom
+  // so we can not get element width to render hidden menu
+  it('should render breadcrumb correctly', () => {
+    const { container } = render(
+      <Breadcrumb
+        items={[
+          {
+            key: '1',
+            name: '1',
+          },
+        ]}
+      />
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('should trigger onClick correctly', async () => {
+    const ref = createRef<HTMLDivElement>();
+    const handleClick = jest.fn();
+
+    const { findByText } = render(
+      <Breadcrumb
+        ref={ref}
+        items={[
+          {
+            key: '1',
+            name: 'Click',
+            onClick: handleClick,
+          },
+          {
+            key: '2',
+            name: 'Not clickable',
+          },
+        ]}
+      />
+    );
+
+    const breadcrumb = await findByText('Click');
+
+    fireEvent.click(breadcrumb);
+
+    expect(handleClick).toBeCalled();
+  });
+});

--- a/packages/tailor-ui/src/Breadcrumb/__tests__/__snapshots__/Breadcrumb.spec.tsx.snap
+++ b/packages/tailor-ui/src/Breadcrumb/__tests__/__snapshots__/Breadcrumb.spec.tsx.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Breadcrumb should render breadcrumb correctly 1`] = `
+.c3 {
+  box-sizing: border-box;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  overflow: hidden;
+  width: 0%;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  box-sizing: border-box;
+  -webkit-flex: auto;
+  -ms-flex: auto;
+  flex: auto;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  overflow: hidden;
+}
+
+.c1 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.c1 svg {
+  fill: #8b8b8b;
+  vertical-align: middle;
+  pointer-events: none;
+  -webkit-transition: all 200ms ease 0s;
+  transition: all 200ms ease 0s;
+}
+
+.c1.c1.c1 svg {
+  fill: #bfbfbf;
+  width: 24px;
+  height: 24px;
+}
+
+.c5 {
+  width: 100%;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c4 {
+  max-width: auto;
+  color: #bfbfbf;
+  font-size: 1rem;
+  font-weight: bold;
+  -webkit-letter-spacing: 0.2px;
+  -moz-letter-spacing: 0.2px;
+  -ms-letter-spacing: 0.2px;
+  letter-spacing: 0.2px;
+  white-space: pre-wrap;
+  cursor: auto;
+  color: #373737;
+  -webkit-transition: all 200ms ease 0s;
+  transition: all 200ms ease 0s;
+}
+
+.c2:hover svg {
+  fill: #3c5ad0 !important;
+}
+
+<div>
+  <div
+    class="c0"
+    overflow="hidden"
+    style="opacity: 0; transition: transition: all 200ms ease 0s;"
+  >
+    <i
+      class="c1 c2"
+      cursor="pointer"
+      fill="gray400"
+      size="24"
+    >
+      <svg
+        fill="currentColor"
+        height="1em"
+        stroke="currentColor"
+        stroke-width="0"
+        viewBox="0 0 24 24"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M6 10c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm12 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm-6 0c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+        />
+      </svg>
+    </i>
+    <div
+      class="c3"
+      display="inline-flex"
+      overflow="hidden"
+      width="0"
+    >
+      <a
+        class="c4"
+      >
+        <div
+          class="c5"
+        >
+          1
+        </div>
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/tailor-ui/src/Breadcrumb/styles.ts
+++ b/packages/tailor-ui/src/Breadcrumb/styles.ts
@@ -8,7 +8,7 @@ interface StyledBreadcrumbLinkProps {
 }
 
 export const StyledBreadcrumbLink = styled.a<StyledBreadcrumbLinkProps>`
-  max-width: ${p => (p.lockWidth ? '200px' : '100%')};
+  max-width: ${p => (p.lockWidth ? '200px' : 'auto')};
   color: ${p => p.theme.colors.gray400};
   font-size: ${p => p.theme.fontSizes.base};
   font-weight: bold;

--- a/packages/tailor-ui/src/PageHeader/PageHeader.tsx
+++ b/packages/tailor-ui/src/PageHeader/PageHeader.tsx
@@ -2,15 +2,16 @@ import React, { FC, ReactNode } from 'react';
 import { MdKeyboardBackspace } from 'react-icons/md';
 
 import { Box, Flex } from '../Layout';
-import { Breadcrumb, BreadcrumbProps } from '../Breadcrumb';
+import { Breadcrumb, BreadcrumbItem } from '../Breadcrumb';
 import { Button } from '../Button';
 import { Ellipsis } from '../Ellipsis';
 import { Heading } from '../Typography';
 
-export interface PageHeaderProps extends BreadcrumbProps {
+export interface PageHeaderProps {
   title?: ReactNode;
   extra?: ReactNode;
   onBack?: () => void;
+  breadcrumb?: BreadcrumbItem[];
 }
 
 const PageHeader: FC<PageHeaderProps> = ({
@@ -42,7 +43,7 @@ const PageHeader: FC<PageHeaderProps> = ({
         {title && breadcrumb.length > 0 && (
           <Box mx="12px" width="1px" height="16px" bg="gray300" />
         )}
-        <Breadcrumb breadcrumb={breadcrumb} />
+        <Breadcrumb items={breadcrumb} />
       </Flex>
       {extra && (
         <Flex alignItems="center" flex="none">

--- a/sidebars.js
+++ b/sidebars.js
@@ -18,7 +18,7 @@ module.exports = {
       'layout/spacing-scale',
       'layout/width-scale',
     ],
-    Navigation: ['dropdown', 'menu', 'page-header', 'steps'],
+    Navigation: ['breadcrumb', 'dropdown', 'menu', 'page-header', 'steps'],
     'Data Entry': [
       'checkbox',
       'date-picker',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2342,6 +2342,11 @@
     "@reach/observe-rect" "^1.0.5"
     prop-types "^15.7.2"
 
+"@reach/utils@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.8.0.tgz#8610590a42bf713d5686e357271609c713bb5c24"
+  integrity sha512-NjOjrFdf7VS6zyTAyXzYgRwLfluECrWe7XLb5Nh9HQA81+9lkvzkR5U9TP07lDDBCup/rFIF56S1XNB/StRrfA==
+
 "@react-spring/mock-raf@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@react-spring/mock-raf/-/mock-raf-1.1.1.tgz#f3d9e17a8c973c8ce286571f1edd63a80414fe5d"


### PR DESCRIPTION
現在 breadcrumb 會在寬度改變的時候 re-render
順便加上一點測試，不過有一些 case 無法測
主要是因為 jsdom 不會 render real dom 所以不會有寬高等等的屬性
但我們的 breadcrumb 是在 effect 用寬度計算決定哪些 item 要藏進 dropdown 裡
所以這部分之後有時間再來研究怎麼測比較好