### PR TITLE
refactor(select): use react-window instead of react-tiny-virtual-list

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/react": "16.9.19",
     "@types/react-dom": "^16.9.5",
     "@types/react-helmet": "^5.0.15",
+    "@types/react-window": "^1.8.1",
     "@types/styled-components": "4.4.2",
     "@types/styled-system": "^5.1.6",
     "@types/yup": "^0.26.30",

--- a/packages/tailor-ui/.size-snapshot.json
+++ b/packages/tailor-ui/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "lib/index.cjs.js": {
-    "bundled": 438345,
-    "minified": 296835,
-    "gzipped": 135035
+    "bundled": 438262,
+    "minified": 296761,
+    "gzipped": 135006
   }
 }

--- a/packages/tailor-ui/package.json
+++ b/packages/tailor-ui/package.json
@@ -46,7 +46,7 @@
     "react-dropzone": "10.2.1",
     "react-helmet": "^6.0.0-beta.2",
     "react-intl-tel-input": "^7.1.0",
-    "react-tiny-virtual-list": "^2.2.0",
+    "react-window": "^1.8.5",
     "styled-normalize": "^8.0.7",
     "styled-system": "^5.1.4"
   },

--- a/packages/tailor-ui/src/Select/SelectOptions.tsx
+++ b/packages/tailor-ui/src/Select/SelectOptions.tsx
@@ -6,7 +6,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import VirtualList from 'react-tiny-virtual-list';
+import { FixedSizeList } from 'react-window';
 import { GetItemPropsOptions } from 'downshift';
 import { MdCheck, MdHighlightOff } from 'react-icons/md';
 
@@ -89,11 +89,18 @@ const SelectOptions: FC<SelectOptionsProps> = ({
   isValidNewOption = value => value.trim() !== '',
   ...props
 }) => {
+  const listRef = useRef<FixedSizeList>(null);
   const [prevSearchValue, setPrevSearchValue] = useState(inputValue);
   const [createOptionWidth, setCreateOptionWidth] = useState<
     number | undefined
   >(undefined);
   const createOptionRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (listRef.current && highlightedIndex) {
+      listRef.current.scrollToItem(highlightedIndex);
+    }
+  }, [highlightedIndex]);
 
   useEffect(() => {
     // save previous inputValue to prevent options reset when options animating fade out
@@ -153,15 +160,15 @@ const SelectOptions: FC<SelectOptionsProps> = ({
       {...getDataTestId(props, 'menu')}
       {...getMenuProps()}
     >
-      <VirtualList
+      <FixedSizeList
+        ref={listRef}
         width="100%"
         height={Math.min(items.length * itemSize, optionsMaxHeight)}
         itemSize={itemSize}
         itemCount={items.length}
-        scrollToIndex={highlightedIndex || 0}
-        overscanCount={3}
-        scrollToAlignment={'auto' as any}
-        renderItem={({ index, style }) => {
+        initialScrollOffset={highlightedIndex ? highlightedIndex * itemSize : 0}
+      >
+        {({ index, style }) => {
           const option = items[index];
           const isCreateOption =
             (option as CreateOption).label === 'CREATE_OPTION';
@@ -212,7 +219,7 @@ const SelectOptions: FC<SelectOptionsProps> = ({
             </StyledSelectOption>
           );
         }}
-      />
+      </FixedSizeList>
       {menu}
     </Box>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,6 +2718,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-window@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.1.tgz#6e1ceab2e6f2f78dbf1f774ee0e00f1bb0364bb3"
+  integrity sha512-V3k1O5cbfZIRa0VVbQ81Ekq/7w42CK1SuiB9U1oPMTxv270D9qUn7rHb3sZoqMkIJFfB1NZxaH7NRDlk+ToDsg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@16.9.19":
   version "16.9.19"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.19.tgz#c842aa83ea490007d29938146ff2e4d9e4360c40"
@@ -9642,6 +9649,11 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
+"memoize-one@>=3.1.1 <6":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
+  integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
+
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -11937,7 +11949,7 @@ promzard@^0.3.0:
   dependencies:
     read "1"
 
-prop-types@15.x, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.1, prop-types@^15.7.2:
+prop-types@15.x, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.1, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -12406,19 +12418,20 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-tiny-virtual-list@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/react-tiny-virtual-list/-/react-tiny-virtual-list-2.2.0.tgz#eafb6fcf764e4ed41150ff9752cdaad8b35edf4a"
-  integrity sha512-MDiy2xyqfvkWrRiQNdHFdm36lfxmcLLKuYnUqcf9xIubML85cmYCgzBJrDsLNZ3uJQ5LEHH9BnxGKKSm8+C0Bw==
-  dependencies:
-    prop-types "^15.5.7"
-
 react-toggle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/react-toggle/-/react-toggle-4.1.1.tgz#2317f67bf918ea3508a96b09dd383efd9da572af"
   integrity sha512-+wXlMcSpg8SmnIXauMaZiKpR+r2wp2gMUteroejp2UTSqGTVvZLN+m9EhMzFARBKEw7KpQOwzCyfzeHeAndQGw==
   dependencies:
     classnames "^2.2.5"
+
+react-window@^1.8.5:
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.5.tgz#a56b39307e79979721021f5d06a67742ecca52d1"
+  integrity sha512-HeTwlNa37AFa8MDZFZOKcNEkuF2YflA0hpGPiTT9vR7OawEt+GZbfM6wqkBahD3D3pUjIabQYzsnY/BSJbgq6Q==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@^16.12.0:
   version "16.12.0"


### PR DESCRIPTION
react-tiny-virtual-list 遲遲不更新 legacy life cycle
直接換成有在維護的 react-window