### PR TITLE
fix: change confirmText & cancelText type to ReactNode

### DIFF
--- a/packages/tailor-ui/src/Modal/Footer.tsx
+++ b/packages/tailor-ui/src/Modal/Footer.tsx
@@ -6,8 +6,8 @@ import { useLocale } from '../locale';
 
 export interface FooterButtonsProps {
   closable?: boolean;
-  cancelText?: string | null;
-  confirmText?: string;
+  cancelText?: ReactNode;
+  confirmText?: ReactNode;
   onConfirm?: MouseEventHandler;
   onCancel?: MouseEventHandler;
   confirmButtonProps?: ButtonProps;

--- a/packages/tailor-ui/src/Modal/HooksModal.tsx
+++ b/packages/tailor-ui/src/Modal/HooksModal.tsx
@@ -18,8 +18,8 @@ export type ModalTypes = StatusType | 'confirm';
 export interface ModalOptions {
   title?: ReactNode;
   content?: ReactNode;
-  confirmText?: string;
-  cancelText?: string;
+  confirmText?: ReactNode;
+  cancelText?: ReactNode;
   onConfirm?: MouseEventHandler;
   onCancel?: MouseEventHandler | KeyboardEventHandler;
   onOpenComplete?: () => void;
@@ -49,8 +49,8 @@ interface EffectModalProps {
 interface ModalOptionsState {
   title?: ReactNode;
   content?: ReactNode;
-  confirmText?: string;
-  cancelText?: string | null;
+  confirmText?: ReactNode;
+  cancelText?: ReactNode;
   onConfirm: MouseEventHandler;
   onCancel: MouseEventHandler | KeyboardEventHandler;
   onOpenComplete?: () => void;

--- a/packages/tailor-ui/src/Popconfirm/Popconfirm.tsx
+++ b/packages/tailor-ui/src/Popconfirm/Popconfirm.tsx
@@ -8,8 +8,8 @@ import { StatusType } from '../types';
 import { useLocale } from '../locale';
 
 export interface PopconfirmContentProps extends PopoverProps {
-  cancelText?: string;
-  confirmText?: string;
+  cancelText?: ReactNode;
+  confirmText?: ReactNode;
   content: ReactNode;
   type?: StatusType;
   onCancel?: (event: MouseEvent) => void;


### PR DESCRIPTION
可以是 ReactNode 才對，product 那邊才不會一直噴 prop type 的錯誤