### PR TITLE
fix(provider): move datePickerStyle from GlobalStyle into its component to prevent tests slowly

### DIFF
--- a/packages/tailor-ui/src/DatePicker/DatePicker.tsx
+++ b/packages/tailor-ui/src/DatePicker/DatePicker.tsx
@@ -12,6 +12,7 @@ import { Position } from '../constants';
 import { useLocale } from '../locale';
 
 import DatePickerInput from './DatePickerInput';
+import DatePickerStyle from './styles';
 import DatePresets, { Presets } from './DatePresets';
 
 export interface DatePickerProps {
@@ -145,56 +146,58 @@ const DatePicker: FC<DatePickerProps> = ({
   }, [format, ownValue]);
 
   return (
-    <Popover
-      position={Position.BOTTOM_LEFT}
-      p="0"
-      content={handleClose => (
-        <RenderCalendar
-          showWeekNumber={false}
-          showDateInput={false}
-          showOk={showTime}
-          format={format}
-          disabledDate={disabledDate}
-          disabledTime={disabledTime}
-          locale={locale.DatePicker}
-          onOk={handleClose}
-          timePicker={
-            showTime ? (
-              <TimePickerPanel
-                minuteStep={minuteStep}
-                showSecond={showSecond}
-              />
-            ) : null
-          }
-          renderSidebar={() => (
-            <DatePresets
-              key="sidebar"
-              presets={presets}
-              onDateClick={handleChange}
-            />
-          )}
-          {...props}
-          {...valueProps}
-          onChange={setDisplayDate}
-          onSelect={(newValue: Moment | Moment[]) => {
-            handleChange(newValue);
-
-            if (!showTime) {
-              handleClose();
+    <DatePickerStyle>
+      <Popover
+        position={Position.BOTTOM_LEFT}
+        p="0"
+        content={handleClose => (
+          <RenderCalendar
+            showWeekNumber={false}
+            showDateInput={false}
+            showOk={showTime}
+            format={format}
+            disabledDate={disabledDate}
+            disabledTime={disabledTime}
+            locale={locale.DatePicker}
+            onOk={handleClose}
+            timePicker={
+              showTime ? (
+                <TimePickerPanel
+                  minuteStep={minuteStep}
+                  showSecond={showSecond}
+                />
+              ) : null
             }
-          }}
+            renderSidebar={() => (
+              <DatePresets
+                key="sidebar"
+                presets={presets}
+                onDateClick={handleChange}
+              />
+            )}
+            {...props}
+            {...valueProps}
+            onChange={setDisplayDate}
+            onSelect={(newValue: Moment | Moment[]) => {
+              handleChange(newValue);
+
+              if (!showTime) {
+                handleClose();
+              }
+            }}
+          />
+        )}
+      >
+        <DatePickerInput
+          width={width}
+          value={displayValue}
+          inputProps={inputProps}
+          clearable={clearable}
+          placeholder={placeholder}
+          handleClear={handleClear}
         />
-      )}
-    >
-      <DatePickerInput
-        width={width}
-        value={displayValue}
-        inputProps={inputProps}
-        clearable={clearable}
-        placeholder={placeholder}
-        handleClear={handleClear}
-      />
-    </Popover>
+      </Popover>
+    </DatePickerStyle>
   );
 };
 

--- a/packages/tailor-ui/src/DatePicker/styles/index.ts
+++ b/packages/tailor-ui/src/DatePicker/styles/index.ts
@@ -1,4 +1,5 @@
-import { css } from 'styled-components';
+import styled from 'styled-components';
+import { Fragment } from 'react';
 
 import Calendar from './Calendar';
 import Common from './common';
@@ -9,7 +10,7 @@ import TimePanel from './TimePanel';
 import YearPanel from './YearPanel';
 import timepicker from './timepicker';
 
-const DatePickerStyle = css`
+const DatePickerStyle = styled(Fragment)`
   ${Calendar};
   ${Common};
   ${DecadePanel};

--- a/packages/tailor-ui/src/GlobalStyle/GlobalStyle.ts
+++ b/packages/tailor-ui/src/GlobalStyle/GlobalStyle.ts
@@ -2,11 +2,8 @@ import { createGlobalStyle } from 'styled-components';
 
 import { globalStyle } from '@tailor-ui/theme';
 
-import datePickerStyle from '../DatePicker/styles';
-
 const GlobalStyle = createGlobalStyle`
   ${globalStyle}
-  ${datePickerStyle}
 `;
 
 export { GlobalStyle };


### PR DESCRIPTION
把 datePickerStyle 從 GlobalStyle 裡移回 DatePicker component 內
此舉可以有效大幅加快測試速度

主要原因是我們的測試 render 時都會使用 UIProvider，這裡面有 GlobalStyle
經過測試後只要把 datePickerStyle 從 GlobalStyle 拿掉就會變很快

Before

```
PASS  packages/tailor-ui/src/Badge/__tests__/Badge.spec.tsx (12.731s)
  Backdrop
    ✓ should render badge correctly (2363ms)
    ✓ should render standalone badge correctly (2344ms)
    ✓ should render customize badge correctly (2080ms)
    ✓ should render overflowCount badge correctly (1947ms)
    ✓ should render customize overflowCount badge correctly (1915ms)
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   3 passed, 3 total
Time:        13.43s
```

After

```
 PASS  packages/tailor-ui/src/Badge/__tests__/Badge.spec.tsx
  Backdrop
    ✓ should render badge correctly (48ms)
    ✓ should render standalone badge correctly (22ms)
    ✓ should render customize badge correctly (77ms)
    ✓ should render overflowCount badge correctly (39ms)
    ✓ should render customize overflowCount badge correctly (14ms)
Test Suites: 1 passed, 1 total
Tests:       5 passed, 5 total
Snapshots:   3 passed, 3 total
Time:        4.729s, estimated 13s
```