### PR TITLE
feat(badge): add new API showZero & animation

### DIFF
--- a/docs/Badge.md
+++ b/docs/Badge.md
@@ -64,13 +64,52 @@ import { Badge } from 'tailor-ui';
 </>
 ```
 
+### Dynamic count
+
+```jsx live
+() => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div>
+      <Badge count={count}>
+        <Button variant={count === 0 ? undefined: 'normal'} icon={MdNotifications} />
+      </Badge>
+      <br />
+      <br />
+      <Button
+        width="36px"
+        size="sm"
+        onClick={() => setCount(count + 1)}
+      >
+        +
+      </Button>
+      <Button
+        ml="2"
+        width="36px"
+        size="sm"
+        onClick={() => {
+          if (count > 0) {
+            setCount(count - 1);
+          }
+        }}
+      >
+        -
+      </Button>
+    </div>
+  );
+}
+```
+
+
 ## API
 
-| Property        | Description             | Type     | Default |
-|-----------------|-------------------------|----------|---------|
-| `count`         | Number to show in badge | `number` |         |
-| `overflowCount` | Max count to show       | `number` | 99      |
-| `wrapperProps`  | Props of badge wrapper  | BoxProps |         |
-| `color`         | Count color             | string   |         |
-| `bg`            | background color        | string   |         |
-| `borderColor`   | border color            | string   |         |
+| Property        | Description                              | Type      | Default |
+|-----------------|------------------------------------------|-----------|---------|
+| `count`         | Number to show in badge                  | `number`  |         |
+| `overflowCount` | Max count to show                        | `number`  | 99      |
+| `showZero`      | Whether to show badge when count is zero | `boolean` | `false` |
+| `wrapperProps`  | Props of badge wrapper                   | BoxProps  |         |
+| `color`         | Count color                              | string    |         |
+| `bg`            | background color                         | string    |         |
+| `borderColor`   | border color                             | string    |         |

--- a/packages/tailor-ui/src/Badge/Badge.tsx
+++ b/packages/tailor-ui/src/Badge/Badge.tsx
@@ -1,11 +1,13 @@
 import React, { ComponentPropsWithRef, FC } from 'react';
+import { useTransition } from 'react-spring';
 
-import { StyledBadge, StyledBadgeWrapper } from './styles';
+import { AnimatedStyledBadge, StyledBadgeWrapper } from './styles';
 
-type StyledBadgeProps = ComponentPropsWithRef<typeof StyledBadge>;
+type StyledBadgeProps = ComponentPropsWithRef<typeof AnimatedStyledBadge>;
 
 export type BadgeProps = StyledBadgeProps & {
   count?: number;
+  showZero?: boolean;
   overflowCount?: number;
   wrapperProps?: ComponentPropsWithRef<typeof StyledBadgeWrapper>;
 };
@@ -13,24 +15,55 @@ export type BadgeProps = StyledBadgeProps & {
 const Badge: FC<BadgeProps> = ({
   count,
   overflowCount = 99,
+  showZero = false,
   wrapperProps,
   children,
   color = 'light',
   bg = 'danger',
   borderColor = 'light',
-  ...props
+  ...otherProps
 }) => {
   const displayCount =
     count && count > overflowCount ? `${overflowCount}+` : count;
+  const transition = useTransition(showZero || count !== 0, null, {
+    from: {
+      opacity: 0,
+      transform: 'scale(0.6)',
+    },
+    enter: {
+      opacity: 1,
+      transform: 'scale(1)',
+    },
+    leave: {
+      opacity: 0,
+      transform: 'scale(0.6)',
+    },
+  });
 
-  const badge = (
-    <StyledBadge color={color} bg={bg} borderColor={borderColor} {...props}>
-      {displayCount}
-    </StyledBadge>
+  const badge = transition.map(
+    ({ item, key, props }) =>
+      item && (
+        <AnimatedStyledBadge
+          key={key}
+          color={color}
+          bg={bg}
+          borderColor={borderColor}
+          {...otherProps}
+          style={{
+            opacity: props.opacity,
+            transformOrigin: children ? 'right' : 'center',
+            transform: props.transform?.interpolate(x =>
+              children ? `${x} translateX(50%)` : x
+            ),
+          }}
+        >
+          {displayCount}
+        </AnimatedStyledBadge>
+      )
   );
 
   if (!children) {
-    return badge;
+    return <>{badge}</>;
   }
 
   return (

--- a/packages/tailor-ui/src/Badge/__tests__/Badge.spec.tsx
+++ b/packages/tailor-ui/src/Badge/__tests__/Badge.spec.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-import { render } from 'test/test-utils';
+import { fireEvent, mockRaf, render, useMockRaf } from 'test/test-utils';
 
 import { Badge } from '../Badge';
 
 describe('Backdrop', () => {
+  useMockRaf();
+
   it('should render badge correctly', async () => {
     const { container } = render(
       <Badge count={2}>
@@ -12,11 +14,15 @@ describe('Backdrop', () => {
       </Badge>
     );
 
+    mockRaf.flush();
+
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should render standalone badge correctly', async () => {
     const { container } = render(<Badge count={2} />);
+
+    mockRaf.flush();
 
     expect(container.firstChild).toMatchSnapshot();
   });
@@ -28,26 +34,101 @@ describe('Backdrop', () => {
       </Badge>
     );
 
+    mockRaf.flush();
+
     expect(container.firstChild).toMatchSnapshot();
   });
 
   it('should render overflowCount badge correctly', async () => {
-    const { getByText } = render(
-      <Badge count={100}>
+    const { getByTestId } = render(
+      <Badge count={100} data-testid="badge">
         <button type="button">btn</button>
       </Badge>
     );
 
-    expect(getByText('99+')).toBeInTheDocument();
+    mockRaf.flush();
+
+    expect(getByTestId('badge')).toHaveTextContent('99+');
   });
 
   it('should render customized overflowCount badge correctly', async () => {
-    const { getByText } = render(
-      <Badge count={1000} overflowCount={999}>
+    const { getByTestId } = render(
+      <Badge count={1000} overflowCount={999} data-testid="badge">
         <button type="button">btn</button>
       </Badge>
     );
 
-    expect(getByText('999+')).toBeInTheDocument();
+    mockRaf.flush();
+
+    expect(getByTestId('badge')).toHaveTextContent('999+');
+  });
+
+  it('should render badge with 0 count when showZero is true', async () => {
+    const { getByTestId } = render(
+      <Badge count={0} showZero data-testid="badge">
+        <button type="button">btn</button>
+      </Badge>
+    );
+
+    mockRaf.flush();
+
+    expect(getByTestId('badge')).toHaveTextContent('0');
+  });
+
+  it('should not render badge with 0 by default', async () => {
+    const { queryByTestId } = render(
+      <Badge count={0} data-testid="badge">
+        <button type="button">btn</button>
+      </Badge>
+    );
+
+    mockRaf.flush();
+
+    expect(queryByTestId('badge')).toBeNull();
+  });
+
+  it('should render badge dynamically', async () => {
+    const DynamicBadge = () => {
+      const [count, setCount] = useState(0);
+
+      return (
+        <div>
+          <Badge count={count} data-testid="badge">
+            <button type="button">btn</button>
+          </Badge>
+          <button
+            data-testid="increment"
+            type="button"
+            onClick={() => setCount(prev => prev + 1)}
+          >
+            +
+          </button>
+          <button
+            data-testid="decrement"
+            type="button"
+            onClick={() => setCount(prev => prev - 1)}
+          >
+            -
+          </button>
+        </div>
+      );
+    };
+
+    const { getByTestId, queryByTestId } = render(<DynamicBadge />);
+
+    mockRaf.flush();
+
+    const incrementBtn = getByTestId('increment');
+    const decrementBtn = getByTestId('decrement');
+
+    expect(queryByTestId('badge')).toBeNull();
+
+    fireEvent.click(incrementBtn);
+    mockRaf.flush();
+    expect(getByTestId('badge')).toHaveTextContent('1');
+
+    fireEvent.click(decrementBtn);
+    mockRaf.flush();
+    expect(queryByTestId('badge')).toBeNull();
   });
 });

--- a/packages/tailor-ui/src/Badge/__tests__/__snapshots__/Badge.spec.tsx.snap
+++ b/packages/tailor-ui/src/Badge/__tests__/__snapshots__/Badge.spec.tsx.snap
@@ -36,9 +36,6 @@ exports[`Backdrop should render badge correctly 1`] = `
   position: absolute;
   top: 0;
   right: 8px;
-  -webkit-transform: translateX(50%);
-  -ms-transform: translateX(50%);
-  transform: translateX(50%);
 }
 
 <div
@@ -52,6 +49,7 @@ exports[`Backdrop should render badge correctly 1`] = `
   <div
     class="sc-1nz5gok-0 c1 c2"
     color="light"
+    style="opacity: 1; transform-origin: right; transform: scale(1) translateX(50%);"
   >
     2
   </div>
@@ -94,9 +92,6 @@ exports[`Backdrop should render customized badge correctly 1`] = `
   position: absolute;
   top: 0;
   right: 8px;
-  -webkit-transform: translateX(50%);
-  -ms-transform: translateX(50%);
-  transform: translateX(50%);
 }
 
 <div
@@ -110,6 +105,7 @@ exports[`Backdrop should render customized badge correctly 1`] = `
   <div
     class="sc-1nz5gok-0 c1 c2"
     color="light"
+    style="opacity: 1; transform-origin: right; transform: scale(1) translateX(50%);"
   >
     16
   </div>
@@ -142,6 +138,7 @@ exports[`Backdrop should render standalone badge correctly 1`] = `
 <div
   class="sc-1nz5gok-0 c0"
   color="light"
+  style="opacity: 1; transform-origin: center; transform: scale(1);"
 >
   2
 </div>

--- a/packages/tailor-ui/src/Badge/styles.ts
+++ b/packages/tailor-ui/src/Badge/styles.ts
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
+import { animated } from 'react-spring';
 
 import { Box } from '../Layout';
 
-export const StyledBadge = styled(Box)`
+const StyledBadge = styled(Box)`
   display: inline-flex;
   align-items: center;
   min-width: 16px;
@@ -14,6 +15,8 @@ export const StyledBadge = styled(Box)`
   line-height: 1;
 `;
 
+export const AnimatedStyledBadge = animated(StyledBadge);
+
 export const StyledBadgeWrapper = styled(Box)`
   display: inline-flex;
   position: relative;
@@ -22,6 +25,5 @@ export const StyledBadgeWrapper = styled(Box)`
     position: absolute;
     top: 0;
     right: 8px;
-    transform: translateX(50%);
   }
 `;


### PR DESCRIPTION
加上 `showZero` 的 API，預設為 false
若 false，當 count 是 0 的時候就不 render
若 true，當 count 是 0 的依然會 render

因應 show/hide 所以加上了 animation