### PR TITLE
fix(ellipsis): adjust tooltip width

### DIFF
--- a/packages/tailor-ui/src/Ellipsis/Ellipsis.tsx
+++ b/packages/tailor-ui/src/Ellipsis/Ellipsis.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 
+import { Box } from '../Layout';
 import { Position } from '../constants';
 import { Tooltip, TooltipProps } from '../Tooltip';
 
@@ -39,7 +40,15 @@ const Ellipsis: FC<EllipsisProps> = ({
 
   return isOverflowed ? (
     <Tooltip
-      content={children}
+      content={
+        <Box
+          minWidth="200px"
+          maxWidth="280px"
+          style={{ whiteSpace: 'pre-line', wordBreak: 'break-word' }}
+        >
+          {children}
+        </Box>
+      }
       position={Position.BOTTOM}
       mouseLeaveDelay={0}
       {...tooltipProps}


### PR DESCRIPTION
- 調整 PageHeader 的 Tooltip 寬度

### Before
![Screenshot 2020-06-11 at 12 01 23](https://user-images.githubusercontent.com/35846199/84343654-5a561580-abdb-11ea-99a6-c39d33a2af45.png)

### After
![Screenshot 2020-06-11 at 11 57 23](https://user-images.githubusercontent.com/35846199/84343656-5c1fd900-abdb-11ea-848e-b281a4d27190.png)
