### PR TITLE
fix(modal): add workaround for hooks modal z-index

### DIFF
--- a/src/Backdrop/Backdrop.tsx
+++ b/src/Backdrop/Backdrop.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { animated, config, useTransition } from 'react-spring';
 
 import { Portal } from '../Portal';
+import { StackingOrder } from '../constants';
 
 const StyledBackdrop = styled.div`
   position: fixed;
@@ -18,9 +19,14 @@ const AnimatedStyledBackdrop = animated(StyledBackdrop);
 
 export interface BackdropProps extends HTMLAttributes<HTMLDivElement> {
   visible: boolean;
+  zIndex?: number;
 }
 
-const Backdrop: FC<BackdropProps> = ({ visible, ...otherProps }) => {
+const Backdrop: FC<BackdropProps> = ({
+  visible,
+  zIndex = StackingOrder.OVERLAY,
+  ...otherProps
+}) => {
   const transition = useTransition(visible, null, {
     from: {
       opacity: 0,
@@ -41,7 +47,7 @@ const Backdrop: FC<BackdropProps> = ({ visible, ...otherProps }) => {
       {transition.map(
         ({ item, key, props }) =>
           item && (
-            <Portal key={key}>
+            <Portal key={key} defaultOrder={zIndex}>
               <AnimatedStyledBackdrop style={props} {...otherProps} />
             </Portal>
           )

--- a/src/Backdrop/__tests__/__snapshots__/Backdrop.spec.tsx.snap
+++ b/src/Backdrop/__tests__/__snapshots__/Backdrop.spec.tsx.snap
@@ -26,7 +26,7 @@ exports[`Backdrop should render backdrop correctly 1`] = `
     portal-container=""
   >
     <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"

--- a/src/Drawer/__tests__/__snapshots__/Drawer.spec.tsx.snap
+++ b/src/Drawer/__tests__/__snapshots__/Drawer.spec.tsx.snap
@@ -206,7 +206,7 @@ exports[`Drawer should render correctly 1`] = `
     portal-container=""
   >
     <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -293,7 +293,7 @@ exports[`Drawer should render correctly with props closable 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -419,7 +419,7 @@ exports[`Drawer should render custom footer correctly 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"

--- a/src/Modal/AnimationModal.tsx
+++ b/src/Modal/AnimationModal.tsx
@@ -32,6 +32,7 @@ export interface AnimationModalProps {
   closable?: boolean;
   status?: StatusType | null;
   visible: boolean;
+  zIndex?: number;
 }
 
 const AnimationModal: FC<AnimationModalProps> = ({
@@ -43,6 +44,7 @@ const AnimationModal: FC<AnimationModalProps> = ({
   closable = true,
   size = 'md',
   status = null,
+  zIndex = StackingOrder.OVERLAY,
   ...otherProps
 }) => {
   const transRef = useRef(null);
@@ -96,6 +98,7 @@ const AnimationModal: FC<AnimationModalProps> = ({
     <>
       <Backdrop
         visible={visible}
+        zIndex={zIndex}
         onClick={(event) => {
           if (closable) {
             onCancel(event as any);
@@ -105,7 +108,7 @@ const AnimationModal: FC<AnimationModalProps> = ({
       {transitions.map(
         ({ item, key, props }) =>
           item && (
-            <Portal key={key} defaultOrder={StackingOrder.OVERLAY}>
+            <Portal key={key} defaultOrder={zIndex}>
               <AnimatedModalWrapper style={props}>
                 {status && (
                   <AnimatedModalStatusBar status={status} style={statusProps} />

--- a/src/Modal/HooksModal.tsx
+++ b/src/Modal/HooksModal.tsx
@@ -25,6 +25,7 @@ export interface ModalOptions {
   onOpenComplete?: () => void;
   onCloseComplete?: () => void;
   closable?: boolean;
+  zIndex?: number;
 }
 
 export type UpdateFunction = (
@@ -57,6 +58,7 @@ interface ModalOptionsState {
   onCloseComplete?: () => void;
   closable: boolean;
   type: ModalTypes;
+  zIndex?: number;
 }
 
 const EffectModal: FC<EffectModalProps> = ({ setTrigger }) => {
@@ -87,6 +89,7 @@ const EffectModal: FC<EffectModalProps> = ({ setTrigger }) => {
         onCancel,
         onOpenComplete,
         onCloseComplete,
+        zIndex,
       } = options;
 
       let resolveFn: (value: boolean) => void = () => {};
@@ -132,6 +135,7 @@ const EffectModal: FC<EffectModalProps> = ({ setTrigger }) => {
         onCancel: handleCancel,
         onOpenComplete,
         onCloseComplete,
+        zIndex,
       });
 
       setVisible(true);
@@ -156,6 +160,7 @@ const EffectModal: FC<EffectModalProps> = ({ setTrigger }) => {
     onCancel,
     onConfirm,
     type,
+    zIndex,
   } = modalOptions;
 
   const status = type !== 'confirm' ? type : null;
@@ -172,6 +177,7 @@ const EffectModal: FC<EffectModalProps> = ({ setTrigger }) => {
       confirmText={confirmText}
       onCancel={onCancel as MouseEventHandler}
       onConfirm={onConfirm}
+      zIndex={zIndex}
       confirmButtonProps={{
         variant: type === 'error' ? 'danger' : 'primary',
       }}

--- a/src/Modal/Modal.tsx
+++ b/src/Modal/Modal.tsx
@@ -8,7 +8,9 @@ import ModalHeader, { ModalHeaderProps } from './Header';
 
 export type ModalProps = AnimationModalProps &
   ModalHeaderProps &
-  ModalFooterProps;
+  ModalFooterProps & {
+    zIndex?: number;
+  };
 
 const Modal: FC<ModalProps> = ({
   title,
@@ -22,9 +24,15 @@ const Modal: FC<ModalProps> = ({
   confirmText,
   confirmButtonProps,
   cancelButtonProps,
+  zIndex,
   ...props
 }) => (
-  <AnimationModal status={status} onCancel={onCancel} {...props}>
+  <AnimationModal
+    status={status}
+    onCancel={onCancel}
+    zIndex={zIndex}
+    {...props}
+  >
     <ModalHeader
       status={status}
       title={title}

--- a/src/Modal/__tests__/__snapshots__/Modal.spec.tsx.snap
+++ b/src/Modal/__tests__/__snapshots__/Modal.spec.tsx.snap
@@ -222,7 +222,7 @@ exports[`Modal should render correctly 1`] = `
     portal-container=""
   >
     <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -298,7 +298,7 @@ exports[`Modal should render correctly with lg size 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -584,7 +584,7 @@ exports[`Modal should render with error status 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -1175,7 +1175,7 @@ exports[`Modal should render with info status 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -1766,7 +1766,7 @@ exports[`Modal should render with props closable 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -2289,7 +2289,7 @@ exports[`Modal should render with success status 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -2880,7 +2880,7 @@ exports[`Modal should render with warning status 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"

--- a/src/Modal/__tests__/__snapshots__/useModal.spec.tsx.snap
+++ b/src/Modal/__tests__/__snapshots__/useModal.spec.tsx.snap
@@ -426,7 +426,7 @@ exports[`useModal should render confirm modal correctly 1`] = `
     portal-container=""
   >
     <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -539,7 +539,7 @@ exports[`useModal should render error modal correctly 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -898,7 +898,7 @@ exports[`useModal should render info modal correctly 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -1257,7 +1257,7 @@ exports[`useModal should render success modal correctly 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"
@@ -1616,7 +1616,7 @@ exports[`useModal should render warning modal correctly 1`] = `
 }
 
 <div
-      style="position: fixed; top: 0px; left: 0px; z-index: 5;"
+      style="position: fixed; top: 0px; left: 0px; z-index: 20;"
     >
       <div
         class="c0"


### PR DESCRIPTION
先讓 hooks modal 提供 z-index props 來調整

```ts
        modal.confirm({
          title: 'Do you Want to delete these items?',
          content: 'Some descriptions',
          onConfirm: () => console.log('confirmed!'),
          onCancel: () => console.log('canceled!'),
          zIndex: 100000,
        });
```