### PR TITLE
fix(select): prevent parent popover disapear when click options of lab select

### DIFF
--- a/src/Popover/Popover.tsx
+++ b/src/Popover/Popover.tsx
@@ -33,7 +33,7 @@ export type PopoverProps = StyledPopoverProps & {
   onCloseComplete?: () => void;
 };
 
-const ClickOutsideContext = createContext<{
+export const ClickOutsideContext = createContext<{
   setHasChild: (hasChild: boolean) => void;
 }>({
   setHasChild: () => {},

--- a/src/lab/Select/Select.tsx
+++ b/src/lab/Select/Select.tsx
@@ -1,12 +1,14 @@
 import React, {
   PropsWithChildren,
   ReactNode,
+  useContext,
   useEffect,
   useRef,
   useState,
 } from 'react';
 import { UseComboboxStateChange, useCombobox } from 'downshift6';
 
+import { ClickOutsideContext } from '../../Popover';
 import { useFormField } from '../../FormField';
 
 import SelectOptions from './SelectOptions';
@@ -60,6 +62,7 @@ const Select = <T extends SelectOption>({
     defaultValue,
   });
 
+  const { setHasChild } = useContext(ClickOutsideContext);
   const selectRef = useRef<HTMLButtonElement>(null);
   const [searchValue, setSearchValue] = useState('');
 
@@ -164,6 +167,7 @@ const Select = <T extends SelectOption>({
     scrollIntoView: () => {},
     onSelectedItemChange: handleChange,
     onInputValueChange: handleInputValueChange,
+    onIsOpenChange: ({ isOpen: visible }) => setHasChild(Boolean(visible)),
   });
 
   const currentSelectedItemString = itemToString(currentSelectedItem);

--- a/website/docs/Popover.md
+++ b/website/docs/Popover.md
@@ -213,18 +213,34 @@ import { Position, Popover } from 'tailor-ui';
   const [value, setValue] = useState('Banana');
 
   return (
-    <Popover
-      position={Position.RIGHT}
-      content={
-        <Select
-          value={value}
-          onChange={setValue}
-          options={['Banana', 'Orange', 'Apple', 'Mango']}
-        />
-      }
-    >
-      <Button>Button</Button>
-    </Popover>
+    <>
+      <Popover
+        position={Position.RIGHT}
+        content={
+          <Select
+            value={value}
+            onChange={setValue}
+            options={['Banana', 'Orange', 'Apple', 'Mango']}
+          />
+        }
+      >
+        <Button>Button</Button>
+      </Popover>
+      <br />
+      <br />
+      <Popover
+        position={Position.RIGHT}
+        content={
+          <Lab.Select
+            value={value}
+            onChange={setValue}
+            options={['Banana', 'Orange', 'Apple', 'Mango']}
+          />
+        }
+      >
+        <Button>Button</Button>
+      </Popover>
+    </>
   );
 }
 ```


### PR DESCRIPTION
## Summary

原本的 Popover 在跟 Lab.Select 混用時會有點選 Select 的 option 時觸發 Popover click outside 的 bug

## Test plan

Bug 重現方法：
- 到 production 文件 https://tailor-ui.netlify.app/docs/popover#popover-with-select
- 把 `code` 裡的 Select 改成 `Lab.Select`
- 點選 Button 選擇任一 Select option，Popover 會觸發關閉