### PR TITLE
fix(date-picker): use customize dateFns config to decrease bundle size

### DIFF
--- a/src/DatePicker/hooks/dateFnsGenerateConfig.ts
+++ b/src/DatePicker/hooks/dateFnsGenerateConfig.ts
@@ -1,0 +1,122 @@
+// Reference: https://github.com/react-component/picker/blob/master/src/generate/dateFns.ts
+import enUS from 'date-fns/locale/en-US';
+import zhTW from 'date-fns/locale/zh-TW';
+import { GenerateConfig } from 'rc-picker/lib/generate';
+import {
+  addDays,
+  addMonths,
+  addYears,
+  endOfMonth,
+  format as formatDate,
+  getDate,
+  getDay,
+  getHours,
+  getMinutes,
+  getMonth,
+  getSeconds,
+  getWeek,
+  getYear,
+  isAfter,
+  isValid,
+  parse as parseDate,
+  setDate,
+  setHours,
+  setMinutes,
+  setMonth,
+  setSeconds,
+  setYear,
+  startOfWeek,
+} from 'date-fns';
+
+const dealLocal = (str: string) => str.replace(/_/g, '') as 'enUS' | 'zhTW';
+
+const Locale = {
+  enUS,
+  zhTW,
+};
+
+const localeParse = (format: string) => {
+  return format
+    .replace(/Y/g, 'y')
+    .replace(/D/g, 'd')
+    .replace(/gggg/, 'yyyy')
+    .replace(/g/g, 'G')
+    .replace(/([Ww])o/g, 'wo');
+};
+
+const generateConfig: GenerateConfig<Date> = {
+  // get
+  getNow: () => new Date(),
+  getFixedDate: (string) => new Date(string),
+  getEndDate: (date) => endOfMonth(date),
+  getWeekDay: (date) => getDay(date),
+  getYear: (date) => getYear(date),
+  getMonth: (date) => getMonth(date),
+  getDate: (date) => getDate(date),
+  getHour: (date) => getHours(date),
+  getMinute: (date) => getMinutes(date),
+  getSecond: (date) => getSeconds(date),
+
+  // set
+  addYear: (date, diff) => addYears(date, diff),
+  addMonth: (date, diff) => addMonths(date, diff),
+  addDate: (date, diff) => addDays(date, diff),
+  setYear: (date, year) => setYear(date, year),
+  setMonth: (date, month) => setMonth(date, month),
+  setDate: (date, num) => setDate(date, num),
+  setHour: (date, hour) => setHours(date, hour),
+  setMinute: (date, minute) => setMinutes(date, minute),
+  setSecond: (date, second) => setSeconds(date, second),
+
+  // Compare
+  isAfter: (date1, date2) => isAfter(date1, date2),
+  isValidate: (date) => isValid(date),
+
+  locale: {
+    getWeekFirstDay: (locale) => {
+      const clone = Locale[dealLocal(locale)];
+      return clone.options?.weekStartsOn ?? 0;
+    },
+    getWeekFirstDate: (locale, date) => {
+      return startOfWeek(date, { locale: Locale[dealLocal(locale)] });
+    },
+    getWeek: (locale, date) => {
+      return getWeek(date, { locale: Locale[dealLocal(locale)] });
+    },
+    getShortWeekDays: (locale) => {
+      const clone = Locale[dealLocal(locale)];
+      return Array.from({ length: 7 }).map((_, i) =>
+        clone.localize?.day(i, { width: 'short' })
+      );
+    },
+    getShortMonths: (locale) => {
+      const clone = Locale[dealLocal(locale)];
+      return Array.from({ length: 12 }).map((_, i) =>
+        clone.localize?.month(i, { width: 'abbreviated' })
+      );
+    },
+    format: (locale, date, format) => {
+      if (!isValid(date)) {
+        return null as any;
+      }
+      return formatDate(date, localeParse(format), {
+        locale: Locale[dealLocal(locale)],
+      });
+    },
+    parse: (locale, text, formats) => {
+      for (let i = 0; i < formats.length; i += 1) {
+        const format = localeParse(formats[i]);
+        const formatText = text;
+        const date = parseDate(formatText, format, new Date(), {
+          locale: Locale[dealLocal(locale)],
+        });
+        if (isValid(date)) {
+          return date;
+        }
+      }
+      return null;
+    },
+  },
+};
+
+export default generateConfig;

--- a/src/DatePicker/hooks/useSharedProps.tsx
+++ b/src/DatePicker/hooks/useSharedProps.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from 'react';
-import dateFnsGenerateConfig from 'rc-picker/lib/generate/dateFns';
 import format from 'date-fns/format';
 import {
   AiOutlineCalendar,
@@ -12,6 +11,8 @@ import {
 
 import { Icon } from '../../Icon';
 import { useLocale } from '../../locale';
+
+import dateFnsGenerateConfig from './dateFnsGenerateConfig';
 
 const useSharedProps = <T extends Record<string, unknown>>(props: T) => {
   const { locale } = useLocale();


### PR DESCRIPTION
## Summary

預設的 dateFns config 把所有 locale 都 import 了導致 bundle size 很大

https://github.com/react-component/picker/blob/master/src/generate/dateFns.ts#L26

<img width="779" alt="screencapture 2021-01-05 下午12 21 43" src="https://user-images.githubusercontent.com/8567270/103608114-86f5c400-4f55-11eb-9958-fed66ac6d79d.png">


這邊改成自己寫一個 config 只 import 有用到的語系來解決這個問題

## Test plan