### PR TITLE
refactor: prefer use ComponentPropWithoutRef to get html props

### DIFF
--- a/src/AutoSizeInput/AutoSizeInput.tsx
+++ b/src/AutoSizeInput/AutoSizeInput.tsx
@@ -1,6 +1,6 @@
 import React, {
   ChangeEvent,
-  InputHTMLAttributes,
+  ComponentPropsWithoutRef,
   forwardRef,
   useEffect,
   useRef,
@@ -20,7 +20,7 @@ const MIN_INPUT_WIDTH = 18;
 
 const AutoSizeInput = forwardRef<
   HTMLInputElement,
-  InputHTMLAttributes<HTMLInputElement> & {
+  ComponentPropsWithoutRef<'input'> & {
     fontSize?: number;
   }
 >(function AutoSizeInput({ fontSize = 14, ...props }, ref) {

--- a/src/Backdrop/Backdrop.tsx
+++ b/src/Backdrop/Backdrop.tsx
@@ -1,4 +1,4 @@
-import React, { FC, HTMLAttributes } from 'react';
+import React, { ComponentPropsWithoutRef, FC } from 'react';
 import styled from 'styled-components';
 import { animated, config, useTransition } from 'react-spring';
 
@@ -17,7 +17,7 @@ const StyledBackdrop = styled.div`
 
 const AnimatedStyledBackdrop = animated(StyledBackdrop);
 
-export interface BackdropProps extends HTMLAttributes<HTMLDivElement> {
+export interface BackdropProps extends ComponentPropsWithoutRef<'div'> {
   visible: boolean;
   zIndex?: number;
 }

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,9 +1,4 @@
-import React, {
-  ButtonHTMLAttributes,
-  ForwardRefExoticComponent,
-  PropsWithoutRef,
-  forwardRef,
-} from 'react';
+import React, { ComponentPropsWithoutRef, forwardRef } from 'react';
 import { SpaceProps, WidthProps } from 'styled-system';
 
 import { IconType } from '../Icon';
@@ -11,7 +6,7 @@ import { IconType } from '../Icon';
 import ButtonIcon from './ButtonIcon';
 import { ButtonSize, ButtonVariant, StyledButton } from './styles';
 
-export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
+export type ButtonProps = ComponentPropsWithoutRef<'button'> &
   SpaceProps &
   WidthProps & {
     loading?: boolean;
@@ -22,9 +17,7 @@ export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> &
     icon?: IconType;
   };
 
-const Button: ForwardRefExoticComponent<
-  PropsWithoutRef<ButtonProps> & React.RefAttributes<HTMLButtonElement>
-> = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   { children, icon, loading = false, size = 'md', ...props },
   ref
 ) {

--- a/src/Card/styles.ts
+++ b/src/Card/styles.ts
@@ -13,7 +13,7 @@ import {
   space,
   width,
 } from 'styled-system';
-import { HTMLAttributes } from 'react';
+import { ComponentPropsWithoutRef } from 'react';
 
 export const StyledImage: StyledComponent<
   'div',
@@ -56,7 +56,7 @@ StyledBlock.defaultProps = {
   p: 3,
 };
 
-export type CardProps = HTMLAttributes<HTMLDivElement> &
+export type CardProps = ComponentPropsWithoutRef<'div'> &
   SpaceProps &
   HeightProps &
   WidthProps &

--- a/src/Icon/Icon.tsx
+++ b/src/Icon/Icon.tsx
@@ -1,10 +1,4 @@
-import React, {
-  FC,
-  ForwardRefExoticComponent,
-  HTMLAttributes,
-  PropsWithoutRef,
-  forwardRef,
-} from 'react';
+import React, { ComponentPropsWithoutRef, FC, forwardRef } from 'react';
 import styled, { css } from 'styled-components';
 import { IconType as ReactIconsIconType } from 'react-icons/lib/esm';
 import { SpaceProps, space, style } from 'styled-system';
@@ -54,7 +48,7 @@ export const IconWrapper = styled.i<IconWrapperProps>`
 
 export type IconType = BuiltInIconKeys | ReactIconsIconType;
 
-export type IconProps = HTMLAttributes<HTMLDivElement> &
+export type IconProps = ComponentPropsWithoutRef<'div'> &
   SpaceProps & {
     cursor?: string;
     pointerEvents?: string;
@@ -64,9 +58,7 @@ export type IconProps = HTMLAttributes<HTMLDivElement> &
     type: IconType;
   };
 
-const Icon: ForwardRefExoticComponent<
-  PropsWithoutRef<IconProps> & React.RefAttributes<HTMLElement>
-> = forwardRef<HTMLElement, IconProps>(function Icon(
+const Icon = forwardRef<HTMLElement, IconProps>(function Icon(
   { type, cursor = 'default', size = 24, ...otherProps },
   ref
 ) {

--- a/src/Tag/Tag.tsx
+++ b/src/Tag/Tag.tsx
@@ -1,7 +1,7 @@
 import React, {
+  ComponentPropsWithoutRef,
   FC,
   FocusEvent,
-  HTMLAttributes,
   KeyboardEvent,
   MouseEventHandler,
   ReactNode,
@@ -64,7 +64,7 @@ const CloseIcon: FC<CloseIconProps> = ({ onClick, disabled, invalid }) => {
 };
 
 export interface TagProps
-  extends Omit<HTMLAttributes<HTMLDivElement>, 'prefix' | 'onChange'> {
+  extends Omit<ComponentPropsWithoutRef<'div'>, 'prefix' | 'onChange'> {
   /**
    * Whether the Tag can be closed
    */


### PR DESCRIPTION
參考這個 https://react-typescript-cheatsheet.netlify.app/docs/advanced/patterns_by_usecase/#wrappingmirroring-a-html-element