### PR TITLE
fix(select): IME bugs & add missing no options message

### DIFF
--- a/src/lab/Select/MultipleSelect.tsx
+++ b/src/lab/Select/MultipleSelect.tsx
@@ -42,6 +42,7 @@ interface MultipleSelectProps<T extends SelectOption> {
   defaultValue?: T[];
   onChange: (item: T[]) => void;
   placeholder?: string;
+  noOptionsMessage?: () => ReactNode;
   onCreateOption?: (value: string) => void;
   formatCreateLabel?: (labelInfo: {
     value: string;
@@ -67,12 +68,14 @@ const MultipleSelect = forwardRef(function MultipleSelect<
     defaultValue,
     onChange,
     placeholder,
+    noOptionsMessage,
     onCreateOption,
     formatCreateLabel = (info) => `Create new option: ${info.value}`,
     isValidNewOption = (optionValue) => optionValue.trim() !== '',
   }: PropsWithoutRef<MultipleSelectProps<T>>,
   ref: Ref<HTMLDivElement>
 ) {
+  const inputRef = useRef<HTMLInputElement>(null);
   const [invalid, labelId, setValue] = useFormField({
     id,
     value,
@@ -165,14 +168,6 @@ const MultipleSelect = forwardRef(function MultipleSelect<
 
       return changes;
     },
-    onStateChange: ({ inputValue, type }) => {
-      if (
-        type === useCombobox.stateChangeTypes.InputChange &&
-        typeof inputValue !== 'undefined'
-      ) {
-        setSearchValue(inputValue);
-      }
-    },
   });
 
   return (
@@ -200,26 +195,30 @@ const MultipleSelect = forwardRef(function MultipleSelect<
               closable
               disabled={loading || disabled}
               style={{ marginBottom: 2 }}
-              onClose={() =>
+              onClose={() => {
                 setSelectedItems(
                   selectedItems.filter(
                     (item) => itemToString(item) !== itemToString(selectedItem)
                   )
-                )
-              }
+                );
+
+                inputRef.current?.focus();
+              }}
               {...getSelectedItemProps({ selectedItem, index })}
             >
               {itemToString(selectedItem)}
             </Tag>
           ))}
           <input
-            {...getInputProps(
-              getDropdownProps({
+            {...getInputProps({
+              ...getDropdownProps({
+                ref: inputRef,
                 preventKeyAction: isOpen,
                 readOnly: (!searchable && !creatable) || loading,
                 placeholder,
-              })
-            )}
+              }),
+              onChange: (event) => setSearchValue(event.currentTarget.value),
+            })}
           />
         </Flex>
         <SelectSuffix
@@ -239,6 +238,7 @@ const MultipleSelect = forwardRef(function MultipleSelect<
         selectedItems={selectedItems}
         highlightedIndex={highlightedIndex}
         formatCreateLabel={formatCreateLabel}
+        noOptionsMessage={noOptionsMessage}
       />
     </div>
   );

--- a/src/lab/Select/Select.tsx
+++ b/src/lab/Select/Select.tsx
@@ -37,6 +37,7 @@ interface SelectProps<T extends SelectOption, V = T | null> {
   defaultValue?: V;
   onChange: (item: V) => void;
   placeholder?: string;
+  noOptionsMessage?: () => ReactNode;
   onCreateOption?: (value: string) => void;
   formatCreateLabel?: (labelInfo: {
     value: string;
@@ -60,6 +61,7 @@ const Select = forwardRef(function Select<T extends SelectOption>(
     defaultValue,
     onChange,
     placeholder,
+    noOptionsMessage,
     onCreateOption,
     formatCreateLabel = (info) => `Create new option: ${info.value}`,
     isValidNewOption = (optionValue) => optionValue.trim() !== '',
@@ -99,19 +101,6 @@ const Select = forwardRef(function Select<T extends SelectOption>(
     }
   };
 
-  const handleInputValueChange = ({
-    inputValue = '',
-    isOpen,
-  }: UseComboboxStateChange<SelectValue | undefined>) => {
-    if (isOpen && (searchable || creatable)) {
-      if (inputValue === CREATE_OPTION) {
-        setSearchValue('');
-      } else {
-        setSearchValue(inputValue);
-      }
-    }
-  };
-
   const getDefaultHighlightIndex = () => {
     if (searchable && searchValue !== '') {
       return 0;
@@ -144,8 +133,12 @@ const Select = forwardRef(function Select<T extends SelectOption>(
     defaultHighlightedIndex: getDefaultHighlightIndex(),
     scrollIntoView: () => {},
     onSelectedItemChange: handleChange,
-    onInputValueChange: handleInputValueChange,
-    onIsOpenChange: ({ isOpen: visible }) => setHasChild(Boolean(visible)),
+    onIsOpenChange: ({ isOpen: visible }) => {
+      setHasChild(Boolean(visible));
+      if (visible) {
+        setSearchValue('');
+      }
+    },
   });
 
   const selectedItemString = itemToString(selectedItem);
@@ -176,6 +169,17 @@ const Select = forwardRef(function Select<T extends SelectOption>(
                 }),
             readOnly: (!searchable && !creatable) || loading,
             placeholder: placeholder ?? selectedItemString,
+            onChange: (event) => {
+              const newInputValue = event.currentTarget.value;
+
+              if (isOpen && (searchable || creatable)) {
+                if (newInputValue === CREATE_OPTION) {
+                  setSearchValue('');
+                } else {
+                  setSearchValue(newInputValue);
+                }
+              }
+            },
           })}
         />
         <SelectSuffix
@@ -195,6 +199,7 @@ const Select = forwardRef(function Select<T extends SelectOption>(
         selectedItem={selectedItem}
         highlightedIndex={highlightedIndex}
         formatCreateLabel={formatCreateLabel}
+        noOptionsMessage={noOptionsMessage}
       />
     </div>
   );

--- a/src/lab/Select/SelectOptions.tsx
+++ b/src/lab/Select/SelectOptions.tsx
@@ -7,14 +7,16 @@ import React, {
   useEffect,
   useRef,
 } from 'react';
-import { MdCheck } from 'react-icons/md';
+import { MdCheck, MdHighlightOff } from 'react-icons/md';
 import { useVirtual } from 'react-virtual';
 
-import { Box } from '../../Layout';
+import { Box, Flex } from '../../Layout';
 import { Ellipsis } from '../../Ellipsis';
+import { Heading } from '../../Typography';
 import { Icon } from '../../Icon';
 import { Stack } from '../../Stack';
 import { Tooltip } from '../../Tooltip';
+import { useLocale } from '../../locale';
 
 import { SelectOption, SelectValue } from './types';
 import { StyledPopover, StyledSelectOption } from './styles';
@@ -24,6 +26,22 @@ import {
   itemToString,
   positionMatchWidth,
 } from './utils';
+
+const DefaultNoOptionsMessage: FC = () => {
+  const { locale } = useLocale();
+
+  return (
+    <Flex
+      py="3"
+      alignItems="center"
+      justifyContent="center"
+      style={{ cursor: 'not-allowed' }}
+    >
+      <Icon type={MdHighlightOff} mr="2" />
+      <Heading.H5 color="gray500">{locale.Select.noDataText}</Heading.H5>
+    </Flex>
+  );
+};
 
 interface SelectOptionsProps {
   selectRef: RefObject<HTMLButtonElement>;
@@ -39,6 +57,7 @@ interface SelectOptionsProps {
     active: boolean;
     hovered: boolean;
   }) => ReactNode;
+  noOptionsMessage?: () => ReactNode;
 }
 
 const SelectOptions: FC<SelectOptionsProps> = ({
@@ -51,6 +70,7 @@ const SelectOptions: FC<SelectOptionsProps> = ({
   selectedItems,
   highlightedIndex,
   formatCreateLabel,
+  noOptionsMessage = () => <DefaultNoOptionsMessage />,
 }) => {
   const listRef = useRef<HTMLDivElement>(null);
   const { virtualItems, totalSize, scrollToIndex } = useVirtual({
@@ -77,67 +97,73 @@ const SelectOptions: FC<SelectOptionsProps> = ({
         >
           <StyledPopover {...getMenuProps({ ref: listRef })}>
             {visible && (
-              <div style={{ height: totalSize }}>
-                {virtualItems.map((virtualRow) => {
-                  const item = options[virtualRow.index];
-                  const itemString = itemToString(item);
-                  const itemDisabled =
-                    (isObjectOption(item) && item.disabled) ?? false;
-                  const hovered = highlightedIndex === virtualRow.index;
-                  const active = selectedItems
-                    ? selectedItems.map(itemToString).includes(itemString)
-                    : itemToString(selectedItem) === itemString;
-                  const content = isCreateOption(item)
-                    ? formatCreateLabel({
-                        value: item.value,
-                        active,
-                        hovered,
-                      })
-                    : itemString;
-                  const hint = isObjectOption(item) ? item.hint : undefined;
+              <>
+                {virtualItems.length === 0 && (
+                  <Box bg="light">{noOptionsMessage()}</Box>
+                )}
 
-                  return (
-                    <StyledSelectOption
-                      key={itemString}
-                      hovered={hovered}
-                      active={active}
-                      {...getItemProps({
-                        item,
-                        index: virtualRow.index,
-                        disabled: itemDisabled,
-                        style: {
-                          height: virtualRow.size,
-                          transform: `translateY(${virtualRow.start}px)`,
-                        },
-                      })}
-                    >
-                      {selectedItems && (
-                        <Box
-                          display="inline-flex"
-                          flex="none"
-                          width="16px"
-                          mr="8px"
-                        >
-                          {active && (
-                            <Icon
-                              type={MdCheck}
-                              fill={hovered ? 'light' : 'primaryLight'}
-                              size="16px"
-                            />
-                          )}
-                        </Box>
-                      )}
-                      {hint ? (
-                        <Tooltip content={hint} mouseLeaveDelay={0}>
-                          <div style={{ width: '100%' }}>{content}</div>
-                        </Tooltip>
-                      ) : (
-                        <Ellipsis>{content}</Ellipsis>
-                      )}
-                    </StyledSelectOption>
-                  );
-                })}
-              </div>
+                <div style={{ height: totalSize }}>
+                  {virtualItems.map((virtualRow) => {
+                    const item = options[virtualRow.index];
+                    const itemString = itemToString(item);
+                    const itemDisabled =
+                      (isObjectOption(item) && item.disabled) ?? false;
+                    const hovered = highlightedIndex === virtualRow.index;
+                    const active = selectedItems
+                      ? selectedItems.map(itemToString).includes(itemString)
+                      : itemToString(selectedItem) === itemString;
+                    const content = isCreateOption(item)
+                      ? formatCreateLabel({
+                          value: item.value,
+                          active,
+                          hovered,
+                        })
+                      : itemString;
+                    const hint = isObjectOption(item) ? item.hint : undefined;
+
+                    return (
+                      <StyledSelectOption
+                        key={itemString}
+                        hovered={hovered}
+                        active={active}
+                        {...getItemProps({
+                          item,
+                          index: virtualRow.index,
+                          disabled: itemDisabled,
+                          style: {
+                            height: virtualRow.size,
+                            transform: `translateY(${virtualRow.start}px)`,
+                          },
+                        })}
+                      >
+                        {selectedItems && (
+                          <Box
+                            display="inline-flex"
+                            flex="none"
+                            width="16px"
+                            mr="8px"
+                          >
+                            {active && (
+                              <Icon
+                                type={MdCheck}
+                                fill={hovered ? 'light' : 'primaryLight'}
+                                size="16px"
+                              />
+                            )}
+                          </Box>
+                        )}
+                        {hint ? (
+                          <Tooltip content={hint} mouseLeaveDelay={0}>
+                            <div style={{ width: '100%' }}>{content}</div>
+                          </Tooltip>
+                        ) : (
+                          <Ellipsis>{content}</Ellipsis>
+                        )}
+                      </StyledSelectOption>
+                    );
+                  })}
+                </div>
+              </>
             )}
           </StyledPopover>
         </Popover>


### PR DESCRIPTION
## Summary

- 修復了 select 的 IME bugs，直接用自己寫的 onChange override downshift 的行為
- 之前漏了 noOptionsMessage 這個 PR 補上
- 修復 select 在搜尋沒有結果按下 enter 導致下次打開時，在 input 出現上次搜尋時的字串
- 現在 multi select 點選 tag 的 x 刪除 item 時，會自動 focus 在 multi select 的 input

## Test plan