### PR TITLE
feat(table): implement scrollable fixed table & usage with Container

### DIFF
--- a/src/Container/Container.tsx
+++ b/src/Container/Container.tsx
@@ -1,10 +1,10 @@
-import React, { FC, ReactNode } from 'react';
+import React, { FC, ReactNode, isValidElement } from 'react';
 
 import { Box, BoxProps } from '../Layout/Box';
 import { Divider } from '../Divider';
 import { Heading, Text } from '../Typography';
 
-import { StyledContainer, StyledSection, StyledSectionTitle } from './styles';
+import { StyledContainer, StyledSection } from './styles';
 
 export interface SectionProps extends Omit<BoxProps, 'color'> {
   title?: ReactNode;
@@ -13,32 +13,93 @@ export interface SectionProps extends Omit<BoxProps, 'color'> {
 const Section: FC<SectionProps> = ({ title, children, ...props }) => {
   return (
     <StyledSection {...props}>
-      {title && <StyledSectionTitle>{title}</StyledSectionTitle>}
+      {title && <Heading.H5 mb="8px">{title}</Heading.H5>}
       {children}
     </StyledSection>
   );
 };
 
-export interface ContainerProps extends Omit<BoxProps, 'color'> {
+const isElementTable = (element: ReactNode) =>
+  isValidElement(element) &&
+  ((element.type as unknown) as { displayName: string }).displayName ===
+    'Table';
+
+interface ContainerTitleProps {
   title?: ReactNode;
   subTitle?: ReactNode;
 }
+
+const ContainerTitle: FC<ContainerTitleProps> = ({ title, subTitle }) => {
+  if (!title && !subTitle) {
+    return null;
+  }
+
+  return (
+    <Box pt="24px" px="32px">
+      {title && <Heading.H4 mb="8px">{title}</Heading.H4>}
+      {subTitle && (
+        <Box mb="8px">
+          <Text color="gray500" fontSize="sm">
+            {subTitle}
+          </Text>
+        </Box>
+      )}
+
+      <Divider mb="24px" />
+    </Box>
+  );
+};
+
+const ContainerChildren: FC = ({ children }) => {
+  const hasChildrenTable = Array.isArray(children)
+    ? children.some(isElementTable)
+    : isElementTable(children);
+
+  if (!hasChildrenTable) {
+    return (
+      <Box px="32px" pb="32px">
+        {children}
+      </Box>
+    );
+  }
+
+  if (!Array.isArray(children)) {
+    return <>{children}</>;
+  }
+
+  const childrenIndex =
+    (Array.isArray(children) &&
+      children.findIndex((child) => isElementTable(child))) ||
+    -1;
+
+  return (
+    <>
+      {children.slice(0, childrenIndex).length > 0 && (
+        <Box py="24px" px="32px">
+          {children.slice(0, childrenIndex)}
+        </Box>
+      )}
+
+      {children[childrenIndex]}
+
+      {children.slice(childrenIndex + 1).length > 0 && (
+        <Box py="24px" px="32px">
+          {children.slice(childrenIndex + 1)}
+        </Box>
+      )}
+    </>
+  );
+};
+
+export type ContainerProps = Omit<BoxProps, 'color'> & ContainerTitleProps;
 
 const Container: FC<ContainerProps> & {
   Section: typeof Section;
 } = ({ title, subTitle, children, ...props }) => {
   return (
     <StyledContainer {...props}>
-      {title && <Heading.H4 mb="8px">{title}</Heading.H4>}
-      {subTitle && (
-        <Box mb="16px">
-          <Text color="gray500" fontSize="sm">
-            {subTitle}
-          </Text>
-        </Box>
-      )}
-      {(title || subTitle) && <Divider mb="24px" />}
-      {children}
+      <ContainerTitle title={title} subTitle={subTitle} />
+      <ContainerChildren>{children}</ContainerChildren>
     </StyledContainer>
   );
 };

--- a/src/Container/__tests__/__snapshots__/Container.spec.tsx.snap
+++ b/src/Container/__tests__/__snapshots__/Container.spec.tsx.snap
@@ -1,6 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Container should render correctly 1`] = `
+.c3 {
+  box-sizing: border-box;
+  padding-top: 24px;
+  padding-left: 32px;
+  padding-right: 32px;
+}
+
+.c6 {
+  box-sizing: border-box;
+  padding-left: 32px;
+  padding-right: 32px;
+  padding-bottom: 32px;
+}
+
 .c1 {
   display: -webkit-box;
   display: -webkit-flex;
@@ -9,7 +23,7 @@ exports[`Container should render correctly 1`] = `
   box-sizing: border-box;
 }
 
-.c3 {
+.c4 {
   font-size: 1.125rem;
   margin: 0;
   color: #283040;
@@ -18,15 +32,16 @@ exports[`Container should render correctly 1`] = `
   margin-bottom: 8px;
 }
 
-.c7 {
+.c9 {
   font-size: 1rem;
   margin: 0;
   color: #283040;
   font-weight: bold;
   line-height: 1.5;
+  margin-bottom: 8px;
 }
 
-.c4 {
+.c5 {
   background-color: #c4cfdd;
   display: block;
   width: 100%;
@@ -47,7 +62,7 @@ exports[`Container should render correctly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  padding: 24px 32px 32px;
+  overflow: hidden;
   border-radius: 1rem;
   background-color: #ffffff;
   box-shadow: 0 2px 4px 0 #C4CFDD;
@@ -55,22 +70,27 @@ exports[`Container should render correctly 1`] = `
   font-size: 1rem;
 }
 
+.c2 .sc-12ad6r6-4 {
+  width: 100%;
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  border-radius: 0;
+  border-color: #c4cfdd;
+  box-shadow: none;
+}
+
 .c0 + .c0 {
   margin-top: 16px;
 }
 
-.c6 {
+.c8 {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
 }
 
-.c5 + .c5 {
+.c7 + .c7 {
   margin-top: 32px;
-}
-
-.c8 {
-  margin-bottom: 12px;
 }
 
 <div>
@@ -78,73 +98,89 @@ exports[`Container should render correctly 1`] = `
     <div
       class="c0 c1 c2"
     >
-      <h4
+      <div
         class="c3"
       >
-        Title A
-      </h4>
-      <div
-        class="c4"
-        color="gray400"
-        font-size="sm"
-        font-weight="500"
-        type="horizontal"
-      />
-      <div
-        class="c5 c1 c6"
-      >
-        <h5
-          class="c7 c8"
+        <h4
+          class="c4"
         >
-          Subtitle #1
-        </h5>
-        Subtitles are text derived from either a transcript or screenplay of the dialog or commentary in films.
+          Title A
+        </h4>
+        <div
+          class="c5"
+          color="gray400"
+          font-size="sm"
+          font-weight="500"
+          type="horizontal"
+        />
       </div>
       <div
-        class="c5 c1 c6"
+        class="c6"
       >
-        <h5
-          class="c7 c8"
+        <div
+          class="c7 c1 c8"
         >
-          Subtitle #2
-        </h5>
-        Subtitles are text derived from either a transcript or screenplay of the dialog or commentary in films.
+          <h5
+            class="c9"
+          >
+            Subtitle #1
+          </h5>
+          Subtitles are text derived from either a transcript or screenplay of the dialog or commentary in films.
+        </div>
+        <div
+          class="c7 c1 c8"
+        >
+          <h5
+            class="c9"
+          >
+            Subtitle #2
+          </h5>
+          Subtitles are text derived from either a transcript or screenplay of the dialog or commentary in films.
+        </div>
       </div>
     </div>
     <div
       class="c0 c1 c2"
     >
-      <h4
+      <div
         class="c3"
       >
-        Title B
-      </h4>
-      <div
-        class="c4"
-        color="gray400"
-        font-size="sm"
-        font-weight="500"
-        type="horizontal"
-      />
-      <div
-        class="c5 c1 c6"
-      >
-        <h5
-          class="c7 c8"
+        <h4
+          class="c4"
         >
-          Subtitle #1
-        </h5>
-        Subtitles are text derived from either a transcript or screenplay of the dialog or commentary in films.
+          Title B
+        </h4>
+        <div
+          class="c5"
+          color="gray400"
+          font-size="sm"
+          font-weight="500"
+          type="horizontal"
+        />
       </div>
       <div
-        class="c5 c1 c6"
+        class="c6"
       >
-        <h5
-          class="c7 c8"
+        <div
+          class="c7 c1 c8"
         >
-          Subtitle #2
-        </h5>
-        Subtitles are text derived from either a transcript or screenplay of the dialog or commentary in films.
+          <h5
+            class="c9"
+          >
+            Subtitle #1
+          </h5>
+          Subtitles are text derived from either a transcript or screenplay of the dialog or commentary in films.
+        </div>
+        <div
+          class="c7 c1 c8"
+        >
+          <h5
+            class="c9"
+          >
+            Subtitle #2
+          </h5>
+          Subtitles are text derived from either a transcript or screenplay of the dialog or commentary in films.
+        </div>
       </div>
     </div>
   </div>

--- a/src/Container/styles.ts
+++ b/src/Container/styles.ts
@@ -1,16 +1,25 @@
 import styled from 'styled-components';
 
 import { Flex } from '../Layout';
-import { Heading } from '../Typography';
+import { StyledTableWrapper } from '../Table/styles';
 
 export const StyledContainer = styled(Flex)`
   flex-direction: column;
-  padding: 24px 32px 32px;
+  overflow: hidden;
   border-radius: ${(p) => p.theme.radii.xl};
   background-color: ${(p) => p.theme.colors.light};
   box-shadow: ${(p) => p.theme.shadows.base};
   color: ${(p) => p.theme.colors.gray700};
   font-size: ${(p) => p.theme.fontSizes.base};
+
+  ${StyledTableWrapper} {
+    width: 100%;
+    border-top: ${(p) => p.theme.borders.base};
+    border-bottom: ${(p) => p.theme.borders.base};
+    border-radius: 0;
+    border-color: ${(p) => p.theme.colors.gray300};
+    box-shadow: none;
+  }
 
   & + & {
     margin-top: 16px;
@@ -23,8 +32,4 @@ export const StyledSection = styled(Flex)`
   & + & {
     margin-top: 32px;
   }
-`;
-
-export const StyledSectionTitle = styled(Heading.H5)`
-  margin-bottom: 12px;
 `;

--- a/src/Table/Column.tsx
+++ b/src/Table/Column.tsx
@@ -1,0 +1,26 @@
+import React, { ReactNode, forwardRef, useMemo, useRef } from 'react';
+import { useForkedRef } from '@reach/utils';
+
+import { StyledColumn } from './styles';
+import { useFixedColumnContext } from './FixedColumnContext';
+
+const Column = forwardRef<HTMLTableDataCellElement, { children: ReactNode }>(
+  function Column({ children, ...props }, forwardedRef) {
+    const ownRef = useRef<HTMLTableDataCellElement>(null);
+    const ref = useForkedRef(forwardedRef, ownRef);
+
+    const { getColumnFixedInfo } = useFixedColumnContext();
+    const fixedInfo = useMemo(
+      () => getColumnFixedInfo(ownRef.current?.cellIndex ?? -1),
+      [getColumnFixedInfo]
+    );
+
+    return (
+      <StyledColumn ref={ref} {...fixedInfo} {...props}>
+        {children}
+      </StyledColumn>
+    );
+  }
+);
+
+export default Column;

--- a/src/Table/FixedColumnContext.tsx
+++ b/src/Table/FixedColumnContext.tsx
@@ -1,0 +1,191 @@
+import React, {
+  ReactNode,
+  createContext,
+  memo,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { CSSProperties } from 'styled-components';
+
+interface FixedColumn {
+  width: number;
+  fixed?: 'left' | 'right';
+}
+
+interface Column extends FixedColumn {
+  index: number;
+}
+
+const FixedColumnContext = createContext<{
+  setColumn: (column: Column) => void;
+  getColumnFixedInfo: (
+    index: number
+  ) => {
+    style?: CSSProperties;
+    fixed?: boolean;
+    showScrollShadowStart?: boolean;
+    showScrollShadowEnd?: boolean;
+    isLastFixedLeft?: boolean;
+    isFirstFixedRight?: boolean;
+  };
+}>({
+  setColumn: () => {},
+  getColumnFixedInfo: () => ({}),
+});
+
+const useFixedColumnContext = () => useContext(FixedColumnContext);
+
+const useFixedHeadColumn = ({
+  index,
+  width,
+  fixed,
+}: {
+  index: number;
+  width: number;
+  fixed?: 'left' | 'right';
+}) => {
+  const { setColumn, getColumnFixedInfo } = useFixedColumnContext();
+
+  useEffect(() => {
+    setColumn({
+      index,
+      width,
+      fixed,
+    });
+  }, [index, width, fixed, setColumn]);
+
+  return useMemo(() => getColumnFixedInfo(index), [getColumnFixedInfo, index]);
+};
+
+interface FixedColumnContextProviderProps {
+  scrollShadowStart: boolean;
+  scrollShadowEnd: boolean;
+  children: ReactNode;
+}
+
+const FixedColumnContextProvider = memo<FixedColumnContextProviderProps>(
+  function FixedColumnContextProvider({
+    children,
+    scrollShadowStart,
+    scrollShadowEnd,
+  }) {
+    const [fixedColumns, setFixedColumns] = useState<FixedColumn[]>([]);
+
+    const setColumn = useCallback((column: Column) => {
+      if (column.index === -1) {
+        return;
+      }
+
+      setFixedColumns((prevColumns) => [
+        ...prevColumns.slice(0, column.index),
+        column,
+        ...prevColumns.slice(column.index + 1),
+      ]);
+    }, []);
+
+    const fixedColumnsInfo = useMemo(() => {
+      return fixedColumns.map((fixedColumn, index) => {
+        if (fixedColumn.fixed === 'left') {
+          const offsetWidth = fixedColumns
+            .slice(0, index)
+            .reduce((prev, curr) => prev + curr.width, 0);
+          const isLastFixedLeft =
+            Math.abs(
+              fixedColumns
+                .slice()
+                .reverse()
+                .findIndex((column) => column.fixed === 'left') -
+                (fixedColumns.length - 1)
+            ) === index;
+
+          return {
+            ...fixedColumn,
+            isLastFixedLeft,
+            style: {
+              left: offsetWidth,
+            },
+          };
+        }
+
+        if (fixedColumn.fixed === 'right') {
+          const offsetWidth = fixedColumns
+            .slice(index + 1)
+            .reduce((prev, curr) => prev + curr.width, 0);
+          const isFirstFixedRight =
+            fixedColumns.findIndex((column) => column.fixed === 'right') ===
+            index;
+
+          return {
+            ...fixedColumn,
+            isFirstFixedRight,
+            style: {
+              right: offsetWidth,
+            },
+          };
+        }
+
+        return { ...fixedColumn, style: {} };
+      });
+    }, [fixedColumns]);
+
+    const getColumnFixedInfo = useCallback(
+      (index: number) => {
+        const targetColumn = fixedColumnsInfo[index];
+
+        if (!targetColumn) {
+          return {};
+        }
+
+        if ('isLastFixedLeft' in targetColumn && targetColumn.isLastFixedLeft) {
+          return {
+            fixed: true,
+            isLastFixedLeft: targetColumn.isLastFixedLeft,
+            showScrollShadowStart: scrollShadowStart,
+            style: targetColumn.style,
+          };
+        }
+
+        if (
+          'isFirstFixedRight' in targetColumn &&
+          targetColumn.isFirstFixedRight
+        ) {
+          return {
+            fixed: true,
+            isFirstFixedRight: targetColumn.isFirstFixedRight,
+            showScrollShadowEnd: scrollShadowEnd,
+            style: targetColumn.style,
+          };
+        }
+
+        return {
+          fixed: typeof targetColumn.fixed === 'string',
+          style: targetColumn.style,
+        };
+      },
+      [fixedColumnsInfo, scrollShadowStart, scrollShadowEnd]
+    );
+
+    const value = useMemo(
+      () => ({
+        setColumn,
+        getColumnFixedInfo,
+      }),
+      [setColumn, getColumnFixedInfo]
+    );
+
+    return (
+      <FixedColumnContext.Provider value={value}>
+        {children}
+      </FixedColumnContext.Provider>
+    );
+  }
+);
+
+export {
+  FixedColumnContextProvider,
+  useFixedColumnContext,
+  useFixedHeadColumn,
+};

--- a/src/Table/HeadColumn.tsx
+++ b/src/Table/HeadColumn.tsx
@@ -1,0 +1,35 @@
+import React, { ReactNode, forwardRef, useRef } from 'react';
+import { WidthProps } from 'styled-system';
+import { useForkedRef } from '@reach/utils';
+
+import { useMeasure } from '../hooks';
+
+import { StyledHeadColumn } from './styles';
+import { useFixedHeadColumn } from './FixedColumnContext';
+
+interface HeadColumnProps extends WidthProps {
+  fixed?: 'left' | 'right';
+  children: ReactNode;
+}
+
+const HeadColumn = forwardRef<HTMLTableHeaderCellElement, HeadColumnProps>(
+  function HeadColumn({ children, fixed, ...props }, forwardedRef) {
+    const ownRef = useRef<HTMLTableHeaderCellElement>(null);
+    const forkedRef = useForkedRef(forwardedRef, ownRef);
+    const [{ ref }, { offsetWidth }] = useMeasure(forkedRef);
+
+    const fixedInfo = useFixedHeadColumn({
+      index: ownRef.current?.cellIndex ?? -1,
+      width: offsetWidth,
+      fixed,
+    });
+
+    return (
+      <StyledHeadColumn ref={ref} {...fixedInfo} {...props}>
+        {children}
+      </StyledHeadColumn>
+    );
+  }
+);
+
+export default HeadColumn;

--- a/src/Table/__tests__/__snapshots__/Table.spec.tsx.snap
+++ b/src/Table/__tests__/__snapshots__/Table.spec.tsx.snap
@@ -2,226 +2,298 @@
 
 exports[`Table should render table correctly 1`] = `
 .c3 {
-  padding: 0.5rem 0.75rem;
+  background-color: #fbfbfd;
+  color: #283040;
   font-weight: bold;
-}
-
-.c4 {
-  padding: 0.5rem 0.75rem;
-}
-
-.c2 {
   height: 56px;
+  padding: 0.5rem 0.75rem;
+  border: none;
   border-bottom: 1px solid #c4cfdd;
   -webkit-transition: all 200ms ease 0s;
   transition: all 200ms ease 0s;
+}
+
+.c3::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: -1px;
+  width: 30px;
+  pointer-events: none;
+  -webkit-transition: all 200ms ease 0s;
+  transition: all 200ms ease 0s;
+}
+
+.c5 {
+  background-color: #ffffff;
+  height: 56px;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-bottom: 1px solid #c4cfdd;
+  -webkit-transition: all 200ms ease 0s;
+  transition: all 200ms ease 0s;
+}
+
+.c5::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: -1px;
+  width: 30px;
+  pointer-events: none;
+  -webkit-transition: all 200ms ease 0s;
+  transition: all 200ms ease 0s;
+}
+
+.c2 {
+  border-top: none;
+}
+
+.c2:last-child > .c4 {
+  border-bottom: none;
+}
+
+.c1 {
+  display: table;
+  margin-bottom: 1px;
+  overflow: auto;
+  border-spacing: 0;
+  border-collapse: separate;
+  border-style: hidden;
+  background-color: #ffffff;
+  font-size: 1rem;
+}
+
+.c1 > tbody > tr:hover > td {
+  background-color: #f6f8fb;
 }
 
 .c0 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  overflow: hidden;
-  border-spacing: 0;
-  border-collapse: collapse;
-  border-style: hidden;
+  overflow: auto;
   border-radius: 1rem;
   background-color: #ffffff;
-  font-size: 1rem;
   box-shadow: 0 2px 4px 0 #C4CFDD;
   width: 100%;
   text-align: center;
 }
 
-.c0 > thead {
-  border-bottom: 1px solid #c4cfdd;
-  background-color: #fbfbfd;
-}
-
-.c0 > tbody > .c1 {
-  background-color: #ffffff;
-}
-
-.c0 > tbody > .c1:hover {
-  background-color: #f6f8fb;
-}
-
-<table
+<div
   class="c0"
   width="100%"
 >
-  <thead>
-    <tr
-      class="c1 c2"
-    >
-      <th
-        class="c3"
+  <table
+    class="c1"
+  >
+    <thead>
+      <tr
+        class="c2"
       >
-        Name
-      </th>
-      <th
-        class="c3"
+        <th
+          class="c3"
+        >
+          Name
+        </th>
+        <th
+          class="c3"
+        >
+          Platform
+        </th>
+        <th
+          class="c3"
+        >
+          People
+        </th>
+        <th
+          class="c3"
+        >
+          Ammount
+        </th>
+        <th
+          class="c3"
+        >
+          Action
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr
+        class="c2"
       >
-        Platform
-      </th>
-      <th
-        class="c3"
+        <td
+          class="c4 c5"
+        >
+          Name 
+          1
+        </td>
+        <td
+          class="c4 c5"
+        >
+          Platform 
+          1
+        </td>
+        <td
+          class="c4 c5"
+        >
+          10,000
+        </td>
+        <td
+          class="c4 c5"
+        >
+          1,000 NTD
+        </td>
+        <td
+          class="c4 c5"
+        >
+          Action
+        </td>
+      </tr>
+      <tr
+        class="c2"
       >
-        People
-      </th>
-      <th
-        class="c3"
+        <td
+          class="c4 c5"
+        >
+          Name 
+          2
+        </td>
+        <td
+          class="c4 c5"
+        >
+          Platform 
+          2
+        </td>
+        <td
+          class="c4 c5"
+        >
+          10,000
+        </td>
+        <td
+          class="c4 c5"
+        >
+          1,000 NTD
+        </td>
+        <td
+          class="c4 c5"
+        >
+          Action
+        </td>
+      </tr>
+      <tr
+        class="c2"
       >
-        Ammount
-      </th>
-      <th
-        class="c3"
-      >
-        Action
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr
-      class="c1 c2"
-    >
-      <td
-        class="c4"
-      >
-        Name 
-        1
-      </td>
-      <td
-        class="c4"
-      >
-        Platform 
-        1
-      </td>
-      <td
-        class="c4"
-      >
-        10,000
-      </td>
-      <td
-        class="c4"
-      >
-        1,000 NTD
-      </td>
-      <td
-        class="c4"
-      >
-        Action
-      </td>
-    </tr>
-    <tr
-      class="c1 c2"
-    >
-      <td
-        class="c4"
-      >
-        Name 
-        2
-      </td>
-      <td
-        class="c4"
-      >
-        Platform 
-        2
-      </td>
-      <td
-        class="c4"
-      >
-        10,000
-      </td>
-      <td
-        class="c4"
-      >
-        1,000 NTD
-      </td>
-      <td
-        class="c4"
-      >
-        Action
-      </td>
-    </tr>
-    <tr
-      class="c1 c2"
-    >
-      <td
-        class="c4"
-      >
-        Name 
-        3
-      </td>
-      <td
-        class="c4"
-      >
-        Platform 
-        3
-      </td>
-      <td
-        class="c4"
-      >
-        10,000
-      </td>
-      <td
-        class="c4"
-      >
-        1,000 NTD
-      </td>
-      <td
-        class="c4"
-      >
-        Action
-      </td>
-    </tr>
-  </tbody>
-</table>
+        <td
+          class="c4 c5"
+        >
+          Name 
+          3
+        </td>
+        <td
+          class="c4 c5"
+        >
+          Platform 
+          3
+        </td>
+        <td
+          class="c4 c5"
+        >
+          10,000
+        </td>
+        <td
+          class="c4 c5"
+        >
+          1,000 NTD
+        </td>
+        <td
+          class="c4 c5"
+        >
+          Action
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 `;
 
 exports[`Table should render table correctly with header and footer 1`] = `
 .c5 {
-  padding: 0.5rem 0.75rem;
+  background-color: #fbfbfd;
+  color: #283040;
   font-weight: bold;
-}
-
-.c6 {
-  padding: 0.5rem 0.75rem;
-}
-
-.c4 {
   height: 56px;
+  padding: 0.5rem 0.75rem;
+  border: none;
   border-bottom: 1px solid #c4cfdd;
   -webkit-transition: all 200ms ease 0s;
   transition: all 200ms ease 0s;
+}
+
+.c5::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: -1px;
+  width: 30px;
+  pointer-events: none;
+  -webkit-transition: all 200ms ease 0s;
+  transition: all 200ms ease 0s;
+}
+
+.c7 {
+  background-color: #ffffff;
+  height: 56px;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-bottom: 1px solid #c4cfdd;
+  -webkit-transition: all 200ms ease 0s;
+  transition: all 200ms ease 0s;
+}
+
+.c7::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  bottom: -1px;
+  width: 30px;
+  pointer-events: none;
+  -webkit-transition: all 200ms ease 0s;
+  transition: all 200ms ease 0s;
+}
+
+.c4 {
+  border-top: none;
+}
+
+.c4:last-child > .c6 {
+  border-bottom: none;
+}
+
+.c3 {
+  display: table;
+  margin-bottom: 1px;
+  overflow: auto;
+  border-spacing: 0;
+  border-collapse: separate;
+  border-style: hidden;
+  background-color: #ffffff;
+  font-size: 1rem;
+}
+
+.c3 > tbody > tr:hover > td {
+  background-color: #f6f8fb;
 }
 
 .c2 {
   -webkit-flex: none;
   -ms-flex: none;
   flex: none;
-  overflow: hidden;
-  border-spacing: 0;
-  border-collapse: collapse;
-  border-style: hidden;
+  overflow: auto;
   border-radius: 1rem;
   background-color: #ffffff;
-  font-size: 1rem;
   width: 100%;
   text-align: center;
-}
-
-.c2 > thead {
-  border-bottom: 1px solid #c4cfdd;
-  background-color: #fbfbfd;
-}
-
-.c2 > tbody > .c3 {
-  background-color: #ffffff;
-}
-
-.c2 > tbody > .c3:hover {
-  background-color: #f6f8fb;
 }
 
 .c0 {
@@ -235,7 +307,7 @@ exports[`Table should render table correctly with header and footer 1`] = `
   width: 100%;
 }
 
-.c0 > .c1 {
+.c0 .c1 {
   width: 100%;
   border-radius: 0;
   border-top: 1px solid #c4cfdd;
@@ -247,137 +319,141 @@ exports[`Table should render table correctly with header and footer 1`] = `
   width="100%"
 >
   Header
-  <table
+  <div
     class="c1 c2"
     width="100%"
   >
-    <thead>
-      <tr
-        class="c3 c4"
-      >
-        <th
-          class="c5"
+    <table
+      class="c3"
+    >
+      <thead>
+        <tr
+          class="c4"
         >
-          Name
-        </th>
-        <th
-          class="c5"
+          <th
+            class="c5"
+          >
+            Name
+          </th>
+          <th
+            class="c5"
+          >
+            Platform
+          </th>
+          <th
+            class="c5"
+          >
+            People
+          </th>
+          <th
+            class="c5"
+          >
+            Ammount
+          </th>
+          <th
+            class="c5"
+          >
+            Action
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class="c4"
         >
-          Platform
-        </th>
-        <th
-          class="c5"
+          <td
+            class="c6 c7"
+          >
+            Name 
+            1
+          </td>
+          <td
+            class="c6 c7"
+          >
+            Platform 
+            1
+          </td>
+          <td
+            class="c6 c7"
+          >
+            10,000
+          </td>
+          <td
+            class="c6 c7"
+          >
+            1,000 NTD
+          </td>
+          <td
+            class="c6 c7"
+          >
+            Action
+          </td>
+        </tr>
+        <tr
+          class="c4"
         >
-          People
-        </th>
-        <th
-          class="c5"
+          <td
+            class="c6 c7"
+          >
+            Name 
+            2
+          </td>
+          <td
+            class="c6 c7"
+          >
+            Platform 
+            2
+          </td>
+          <td
+            class="c6 c7"
+          >
+            10,000
+          </td>
+          <td
+            class="c6 c7"
+          >
+            1,000 NTD
+          </td>
+          <td
+            class="c6 c7"
+          >
+            Action
+          </td>
+        </tr>
+        <tr
+          class="c4"
         >
-          Ammount
-        </th>
-        <th
-          class="c5"
-        >
-          Action
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr
-        class="c3 c4"
-      >
-        <td
-          class="c6"
-        >
-          Name 
-          1
-        </td>
-        <td
-          class="c6"
-        >
-          Platform 
-          1
-        </td>
-        <td
-          class="c6"
-        >
-          10,000
-        </td>
-        <td
-          class="c6"
-        >
-          1,000 NTD
-        </td>
-        <td
-          class="c6"
-        >
-          Action
-        </td>
-      </tr>
-      <tr
-        class="c3 c4"
-      >
-        <td
-          class="c6"
-        >
-          Name 
-          2
-        </td>
-        <td
-          class="c6"
-        >
-          Platform 
-          2
-        </td>
-        <td
-          class="c6"
-        >
-          10,000
-        </td>
-        <td
-          class="c6"
-        >
-          1,000 NTD
-        </td>
-        <td
-          class="c6"
-        >
-          Action
-        </td>
-      </tr>
-      <tr
-        class="c3 c4"
-      >
-        <td
-          class="c6"
-        >
-          Name 
-          3
-        </td>
-        <td
-          class="c6"
-        >
-          Platform 
-          3
-        </td>
-        <td
-          class="c6"
-        >
-          10,000
-        </td>
-        <td
-          class="c6"
-        >
-          1,000 NTD
-        </td>
-        <td
-          class="c6"
-        >
-          Action
-        </td>
-      </tr>
-    </tbody>
-  </table>
+          <td
+            class="c6 c7"
+          >
+            Name 
+            3
+          </td>
+          <td
+            class="c6 c7"
+          >
+            Platform 
+            3
+          </td>
+          <td
+            class="c6 c7"
+          >
+            10,000
+          </td>
+          <td
+            class="c6 c7"
+          >
+            1,000 NTD
+          </td>
+          <td
+            class="c6 c7"
+          >
+            Action
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
   Footer
 </div>
 `;

--- a/src/Table/styles.ts
+++ b/src/Table/styles.ts
@@ -1,64 +1,122 @@
-import styled, { DefaultTheme, StyledComponent, css } from 'styled-components';
+import styled, { css } from 'styled-components';
 import { TextAlignProps, WidthProps, textAlign, width } from 'styled-system';
 
-export const HeadColumn: StyledComponent<
-  'th',
-  DefaultTheme,
-  WidthProps,
-  never
-> = styled.th<WidthProps>`
-  padding: ${(p) => p.theme.paddings.xs} ${(p) => p.theme.paddings.sm};
-  font-weight: bold;
+interface ShadowType {
+  showScrollShadowStart?: boolean;
+  showScrollShadowEnd?: boolean;
+  isLastFixedLeft?: boolean;
+  isFirstFixedRight?: boolean;
+  fixed?: boolean;
+}
 
-  ${width};
-`;
-
-export const Column = styled.td`
-  padding: ${(p) => p.theme.paddings.xs} ${(p) => p.theme.paddings.sm};
-`;
-
-export const Row = styled.tr`
+const columnSharedStyle = css<ShadowType>`
   height: 56px;
+  padding: ${(p) => p.theme.paddings.xs} ${(p) => p.theme.paddings.sm};
+  border: none;
   border-bottom: ${(p) => p.theme.borders.base} ${(p) => p.theme.colors.gray300};
 
+  ${(p) =>
+    p.fixed &&
+    css`
+      position: sticky;
+      z-index: 5;
+    `}
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: -1px;
+    width: 30px;
+    pointer-events: none;
+    ${(p) => p.theme.transition};
+
+    ${(p) =>
+      p.isLastFixedLeft &&
+      css`
+        right: 0;
+        transform: translateX(100%);
+      `}
+
+    ${(p) =>
+      p.isFirstFixedRight &&
+      css`
+        left: 0;
+        transform: translateX(-100%);
+      `}
+
+    ${(p) =>
+      p.showScrollShadowStart &&
+      css`
+        box-shadow: inset 10px 0 8px -8px rgb(0 0 0 / 15%);
+      `}
+
+    ${(p) =>
+      p.showScrollShadowEnd &&
+      css`
+        box-shadow: inset -10px 0 8px -8px rgb(0 0 0 / 15%);
+      `}
+  }
+`;
+
+export const StyledHeadColumn = styled.th<WidthProps & ShadowType>`
+  background-color: ${(p) => p.theme.colors.surface2};
+  color: ${(p) => p.theme.colors.gray700};
+  font-weight: bold;
+
+  ${columnSharedStyle};
+  ${width};
   ${(p) => p.theme.transition};
 `;
 
-export type StyledTableProps = TextAlignProps &
+export const StyledColumn = styled.td<ShadowType>`
+  background-color: ${(p) => p.theme.colors.light};
+
+  ${columnSharedStyle};
+  ${(p) => p.theme.transition};
+`;
+
+export const Row = styled.tr`
+  border-top: none;
+
+  &:last-child > ${StyledColumn} {
+    border-bottom: none;
+  }
+`;
+
+export const StyledTable = styled.table`
+  display: table;
+  margin-bottom: 1px;
+  overflow: auto;
+  border-spacing: 0;
+  border-collapse: separate;
+  border-style: hidden;
+  background-color: ${(p) => p.theme.colors.light};
+  font-size: ${(p) => p.theme.fontSizes.base};
+
+  & > tbody > tr:hover > td {
+    background-color: ${(p) => p.theme.colors.gray100};
+  }
+`;
+
+export type StyledTableWrapperProps = TextAlignProps &
   WidthProps & {
     hasHeader: boolean;
     hasFooter: boolean;
   };
 
-export const StyledTable = styled.table<StyledTableProps>`
+export const StyledTableWrapper = styled.div<StyledTableWrapperProps>`
   flex: none;
-  overflow: hidden;
-  border-spacing: 0;
-  border-collapse: collapse;
-  border-style: hidden;
+  overflow: auto;
   border-radius: ${(p) => p.theme.radii.xl};
   background-color: ${(p) => p.theme.colors.light};
-  font-size: ${(p) => p.theme.fontSizes.base};
+
   ${(p) =>
     !p.hasHeader &&
     !p.hasFooter &&
     css`
       box-shadow: ${p.theme.shadows.base};
     `}
-
-  & > thead {
-    border-bottom: ${(p) => p.theme.borders.base}
-      ${(p) => p.theme.colors.gray300};
-    background-color: ${(p) => p.theme.colors.surface2};
-  }
-
-  & > tbody > ${Row /* sc-selector */} {
-    background-color: ${(p) => p.theme.colors.light};
-
-    &:hover {
-      background-color: ${(p) => p.theme.colors.gray100};
-    }
-  }
 
   ${width};
   ${textAlign};
@@ -77,7 +135,7 @@ export const TableWrapper = styled.div<TableWrapperProps>`
   box-shadow: ${(p) => p.theme.shadows.base};
 
   /* stylelint-disable-next-line no-descending-specificity */
-  & > ${StyledTable} {
+  & ${StyledTableWrapper} {
     width: 100%;
     border-radius: 0;
 

--- a/src/hooks/useMeasure.ts
+++ b/src/hooks/useMeasure.ts
@@ -13,13 +13,19 @@ const useMeasure = (targetRef: Ref<any> = null) => {
     top: 0,
     width: 0,
     height: 0,
+    offsetWidth: 0,
+    offsetHeight: 0,
   });
 
   const [ro] = useState(
     () =>
-      new ResizeObserver(([entry]: ResizeObserverEntry[]) =>
-        set(entry.contentRect)
-      )
+      new ResizeObserver(([entry]: ResizeObserverEntry[]) => {
+        set({
+          ...entry.contentRect,
+          offsetWidth: entry.target.clientWidth,
+          offsetHeight: entry.target.clientWidth,
+        });
+      })
   );
 
   useEffect(() => {

--- a/website/docs/Container.md
+++ b/website/docs/Container.md
@@ -43,6 +43,42 @@ import { Container, Box } from 'tailor-ui';
 </Box>
 ```
 
+
+### With Table
+
+```jsx live
+<Box p="24px" bg="surface2">
+  <Container>
+    <Heading.H4>Text Here</Heading.H4>
+
+    <Table>
+      <Table.Head>
+        <Table.HeadColumn>Name</Table.HeadColumn>
+        <Table.HeadColumn>Platform</Table.HeadColumn>
+        <Table.HeadColumn>People</Table.HeadColumn>
+        <Table.HeadColumn>Ammount</Table.HeadColumn>
+        <Table.HeadColumn>Action</Table.HeadColumn>
+      </Table.Head>
+      <Table.Body>
+        {range(1, 4).map(value => (
+          <Table.Row key={value}>
+            <Table.Column>Name {value}</Table.Column>
+            <Table.Column>Platform {value}</Table.Column>
+            <Table.Column>10,000</Table.Column>
+            <Table.Column>NTD 1,000</Table.Column>
+            <Table.Column>
+              <Button variant="primary-invert">Action</Button>
+            </Table.Column>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+
+    <Button variant="regular">+ Button</Button>
+  </Container>
+</Box>
+```
+
 ## API
 
 ### Container

--- a/website/docs/Table.md
+++ b/website/docs/Table.md
@@ -34,7 +34,7 @@ import { Table } from 'tailor-ui';
           <Table.Column>Name {value}</Table.Column>
           <Table.Column>Platform {value}</Table.Column>
           <Table.Column>10,000</Table.Column>
-          <Table.Column>1,000 NTD</Table.Column>
+          <Table.Column>NTD 1,000</Table.Column>
           <Table.Column>
             <Button variant="primary-invert">Action</Button>
           </Table.Column>
@@ -45,10 +45,12 @@ import { Table } from 'tailor-ui';
 </Box>
 ```
 
-### Header & Footer
+### Header & Footer (Deprecated)
+
+> This API will be deprecated in the future, please use Container wrap Table instead.
 
 ```jsx live
-<Box width="100%" height="100%" borderRadius="xl" bg="#eef0f5" p="4">
+<Box width="100%" height="100%" borderRadius="xl" bg="surface" p="4">
   <Table
     header={
       <Box py="24px" px="4">
@@ -74,7 +76,7 @@ import { Table } from 'tailor-ui';
           <Table.Column>Name {value}</Table.Column>
           <Table.Column>Platform {value}</Table.Column>
           <Table.Column>10,000</Table.Column>
-          <Table.Column>1,000 NTD</Table.Column>
+          <Table.Column>NTD 1,000</Table.Column>
           <Table.Column>
             <Button variant="primary-invert">Action</Button>
           </Table.Column>
@@ -82,6 +84,87 @@ import { Table } from 'tailor-ui';
       ))}
     </Table.Body>
   </Table>
+</Box>
+```
+
+### Scrollable
+
+```jsx live
+<Box width="100%" height="100%" borderRadius="xl" bg="surface" p="4">
+  <Container>
+    <Heading.H4>Text Here</Heading.H4>
+    <Table>
+      <Table.Head>
+        <Table.HeadColumn fixed="left">
+          <Box width="100px">
+            Column
+          </Box>
+        </Table.HeadColumn>
+        <Table.HeadColumn fixed="left">
+          <Box width="100px">
+            Column
+          </Box>
+        </Table.HeadColumn>
+        <Table.HeadColumn>
+          <Box width="160px">
+            Scrollable Column
+          </Box>
+        </Table.HeadColumn>
+        <Table.HeadColumn>
+          <Box width="160px">
+            Scrollable Column
+          </Box>
+        </Table.HeadColumn>
+        <Table.HeadColumn>
+          <Box width="160px">
+            Scrollable Column
+          </Box>
+        </Table.HeadColumn>
+        <Table.HeadColumn>
+          <Box width="160px">
+            Scrollable Column
+          </Box>
+        </Table.HeadColumn>
+        <Table.HeadColumn>
+          <Box width="160px">
+            Scrollable Column
+          </Box>
+        </Table.HeadColumn>
+        <Table.HeadColumn>
+          <Box width="160px">
+            Scrollable Column
+          </Box>
+        </Table.HeadColumn>
+        <Table.HeadColumn fixed="right">
+          <Box width="100px">
+            Column
+          </Box>
+        </Table.HeadColumn>
+      </Table.Head>
+      <Table.Body>
+        {range(1, 10).map(value => (
+          <Table.Row key={value}>
+            <Table.Column>
+              Column {value}
+            </Table.Column>
+            <Table.Column>
+              Column {value}
+            </Table.Column>
+            <Table.Column>Scrollable Column {value}</Table.Column>
+            <Table.Column>Scrollable Column {value}</Table.Column>
+            <Table.Column>Scrollable Column {value}</Table.Column>
+            <Table.Column>Scrollable Column {value}</Table.Column>
+            <Table.Column>Scrollable Column {value}</Table.Column>
+            <Table.Column>Scrollable Column {value}</Table.Column>
+            <Table.Column>
+              Column {value}
+            </Table.Column>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+    <Button variant="regular">+ Button</Button>
+  </Container>
 </Box>
 ```
 
@@ -130,7 +213,7 @@ import { Table } from 'tailor-ui';
           <Table.Column>Name {value}</Table.Column>
           <Table.Column>Platform {value}</Table.Column>
           <Table.Column>10,000</Table.Column>
-          <Table.Column>1,000 NTD</Table.Column>
+          <Table.Column>NTD 1,000</Table.Column>
           <Table.Column>
             <Button variant="primary-invert">Action</Button>
           </Table.Column>


### PR DESCRIPTION
## Summary

- 未來會移除 Table 的 Header 及 Footer props，直接將 Table 包在 Container 裡即可達到一樣的效果
	- [新 API（與 Container 合併使用）](https://deploy-preview-523--tailor-ui.netlify.app/docs/container#with-table)
	- [舊 API（`header` & `footer` props）](https://deploy-preview-523--tailor-ui.netlify.app/docs/table#header--footer-deprecated)
- 實作 Table 的 fixed 功能讓它可以左右捲動
    - [Preview](https://deploy-preview-523--tailor-ui.netlify.app/docs/table#scrollable)

## Test plan

看 Preview