### PR TITLE
fix: use isomorphic effect to prevent hooks method not work in effect

### DIFF
--- a/src/Modal/HooksModal.tsx
+++ b/src/Modal/HooksModal.tsx
@@ -2,11 +2,12 @@ import React, {
   FC,
   KeyboardEventHandler,
   MouseEventHandler,
+  MutableRefObject,
   ReactNode,
   useCallback,
-  useEffect,
   useState,
 } from 'react';
+import { useIsomorphicLayoutEffect } from '@reach/utils';
 
 import { StatusType } from '../types';
 import { useLocale } from '../locale';
@@ -44,7 +45,7 @@ export type Trigger = (
 ) => TriggerResponse;
 
 interface HooksModalProps {
-  setTrigger: (trigger: Trigger) => void;
+  modalTriggerRef: MutableRefObject<Trigger>;
 }
 
 interface ModalOptionsState {
@@ -61,7 +62,7 @@ interface ModalOptionsState {
   zIndex?: number;
 }
 
-const HooksModal: FC<HooksModalProps> = ({ setTrigger }) => {
+const HooksModal: FC<HooksModalProps> = ({ modalTriggerRef }) => {
   const { locale } = useLocale();
   const [visible, setVisible] = useState(false);
   const [modalOptions, setModalOptions] = useState<ModalOptionsState>({
@@ -165,9 +166,10 @@ const HooksModal: FC<HooksModalProps> = ({ setTrigger }) => {
 
   const status = type !== 'confirm' ? type : null;
 
-  useEffect(() => {
-    setTrigger(trigger);
-  }, [setTrigger, trigger]);
+  useIsomorphicLayoutEffect(() => {
+    // eslint-disable-next-line no-param-reassign
+    modalTriggerRef.current = trigger;
+  }, [modalTriggerRef, trigger]);
 
   return (
     <Modal

--- a/src/message/HooksMessage.tsx
+++ b/src/message/HooksMessage.tsx
@@ -3,13 +3,13 @@ import React, {
   MutableRefObject,
   ReactNode,
   useCallback,
-  useEffect,
   useRef,
   useState,
 } from 'react';
 import styled from 'styled-components';
 import { MdClose } from 'react-icons/md';
 import { animated, useTransition } from 'react-spring';
+import { useIsomorphicLayoutEffect } from '@reach/utils';
 
 import { Box } from '../Layout';
 import { Icon } from '../Icon';
@@ -90,7 +90,7 @@ const HooksMessage: FC<HooksMessageProps> = ({ triggerRef }) => {
   const [messages, setMessages] = useState<Message[]>([]);
   const getUid = useUID();
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     setMounted(true);
   }, []);
 
@@ -114,7 +114,7 @@ const HooksMessage: FC<HooksMessageProps> = ({ triggerRef }) => {
     [getUid]
   );
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // eslint-disable-next-line no-param-reassign
     triggerRef.current = trigger;
   }, [trigger, triggerRef]);

--- a/src/notification/HooksNotification.tsx
+++ b/src/notification/HooksNotification.tsx
@@ -3,13 +3,13 @@ import React, {
   MutableRefObject,
   ReactNode,
   useCallback,
-  useEffect,
   useRef,
   useState,
 } from 'react';
 import styled from 'styled-components';
 import { MdClose } from 'react-icons/md';
 import { animated, to, useTransition } from 'react-spring';
+import { useIsomorphicLayoutEffect } from '@reach/utils';
 
 import { Box, Flex } from '../Layout';
 import { Icon } from '../Icon';
@@ -82,7 +82,7 @@ const HooksNotification: FC<HooksNotificationProps> = ({ triggerRef }) => {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const getUid = useUID();
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     setMounted(true);
   }, []);
 
@@ -126,7 +126,7 @@ const HooksNotification: FC<HooksNotificationProps> = ({ triggerRef }) => {
     cancelMap.current.forEach((cancelCallback) => cancelCallback());
   };
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     // eslint-disable-next-line no-param-reassign
     triggerRef.current = {
       open: trigger,


### PR DESCRIPTION
## Summary

useEffect 是作用在 DOM mounted 之後
如果使用 hooks function 的地方位於 useEffect 裡的話
會執行到還沒被 assign 的預設值 trigger 導致沒有作用

把 assign trigger 改成 useLayoutEffect 後可以確保 useEffect 裡執行的 method 是被 assign 後的 trigger

## Test plan