### PR TITLE
fix: blurry bugs

### DIFF
--- a/src/theme/globalStyle.ts
+++ b/src/theme/globalStyle.ts
@@ -25,6 +25,8 @@ export const globalStyle = css`
     font-family: Roboto, 'PingFang TC', 'Microsoft JhengHei', 'Helvetica Neue',
       sans-serif;
     font-size: ${rem('16px')};
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
   }
 


### PR DESCRIPTION
## Summary

https://yoctol.atlassian.net/browse/SEEK-2140

猜這這個跟字體平滑有關係
所以預設把字體平滑功能打開

[caniuse](https://caniuse.com/font-smooth)
Ref: https://stackoverflow.com/questions/27385126/chrome-font-appears-blurry

## Test plan